### PR TITLE
Ensure asset link identifiers are generated server-side

### DIFF
--- a/src/main/java/com/db/assetstore/domain/model/link/AssetLink.java
+++ b/src/main/java/com/db/assetstore/domain/model/link/AssetLink.java
@@ -1,0 +1,30 @@
+package com.db.assetstore.domain.model.link;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+/**
+ * Domain view of an asset link.
+ */
+@Getter
+@Builder(toBuilder = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AssetLink {
+    private final String id;
+    private final String assetId;
+    private final String linkCode;
+    private final String linkSubtype;
+    private final String entityType;
+    private final String entityId;
+    private final boolean active;
+    private final boolean deleted;
+    private final Instant validFrom;
+    private final Instant validTo;
+    private final Instant createdAt;
+    private final String createdBy;
+    private final Instant modifiedAt;
+    private final String modifiedBy;
+}

--- a/src/main/java/com/db/assetstore/domain/model/link/LinkCardinality.java
+++ b/src/main/java/com/db/assetstore/domain/model/link/LinkCardinality.java
@@ -1,0 +1,10 @@
+package com.db.assetstore.domain.model.link;
+
+/**
+ * Cardinality configuration for an asset link definition.
+ */
+public enum LinkCardinality {
+    ONE_TO_ONE,
+    ONE_TO_MANY,
+    MANY_TO_ONE
+}

--- a/src/main/java/com/db/assetstore/domain/model/link/LinkDefinition.java
+++ b/src/main/java/com/db/assetstore/domain/model/link/LinkDefinition.java
@@ -1,0 +1,19 @@
+package com.db.assetstore.domain.model.link;
+
+import lombok.Builder;
+import lombok.Singular;
+
+import java.util.Set;
+
+/**
+ * Domain representation of link definition metadata.
+ */
+@Builder(toBuilder = true)
+public record LinkDefinition(
+        String code,
+        String entityType,
+        LinkCardinality cardinality,
+        boolean enabled,
+        @Singular Set<String> subtypes
+) {
+}

--- a/src/main/java/com/db/assetstore/domain/service/AssetCommandService.java
+++ b/src/main/java/com/db/assetstore/domain/service/AssetCommandService.java
@@ -2,8 +2,14 @@ package com.db.assetstore.domain.service;
 
 import com.db.assetstore.domain.service.cmd.CreateAssetCommand;
 import com.db.assetstore.domain.service.cmd.PatchAssetCommand;
+import com.db.assetstore.domain.service.link.cmd.CreateAssetLinkCommand;
+import com.db.assetstore.domain.service.link.cmd.DeleteAssetLinkCommand;
+import com.db.assetstore.domain.service.link.cmd.PatchAssetLinkCommand;
 
 public interface AssetCommandService {
     String create(CreateAssetCommand command);
     void update(PatchAssetCommand command);
+    String createLink(CreateAssetLinkCommand command);
+    void deleteLink(DeleteAssetLinkCommand command);
+    void patchLink(PatchAssetLinkCommand command);
 }

--- a/src/main/java/com/db/assetstore/domain/service/AssetQueryService.java
+++ b/src/main/java/com/db/assetstore/domain/service/AssetQueryService.java
@@ -1,5 +1,6 @@
 package com.db.assetstore.domain.service;
 
+import com.db.assetstore.domain.model.link.AssetLink;
 import com.db.assetstore.domain.model.Asset;
 import com.db.assetstore.domain.search.SearchCriteria;
 import org.springframework.data.domain.Page;
@@ -11,4 +12,6 @@ import java.util.Optional;
 public interface AssetQueryService {
     Optional<Asset> get(String id);
     List<Asset> search(SearchCriteria criteria);
+    List<AssetLink> findLinksByAsset(String assetId, boolean activeOnly);
+    List<AssetLink> findLinksByEntity(String entityType, String entityId, boolean activeOnly);
 }

--- a/src/main/java/com/db/assetstore/domain/service/link/cmd/CreateAssetLinkCommand.java
+++ b/src/main/java/com/db/assetstore/domain/service/link/cmd/CreateAssetLinkCommand.java
@@ -1,0 +1,26 @@
+package com.db.assetstore.domain.service.link.cmd;
+
+import lombok.Builder;
+
+import java.time.Instant;
+
+/**
+ * Command describing creation of a link between an asset and an external entity.
+ */
+@Builder
+public record CreateAssetLinkCommand(
+        String assetId,
+        String linkCode,
+        String linkSubtype,
+        String entityType,
+        String entityId,
+        Boolean active,
+        Instant validFrom,
+        Instant validTo,
+        String requestedBy,
+        Instant requestTime
+) {
+    public boolean shouldActivate() {
+        return active == null || active;
+    }
+}

--- a/src/main/java/com/db/assetstore/domain/service/link/cmd/DeleteAssetLinkCommand.java
+++ b/src/main/java/com/db/assetstore/domain/service/link/cmd/DeleteAssetLinkCommand.java
@@ -1,0 +1,17 @@
+package com.db.assetstore.domain.service.link.cmd;
+
+import lombok.Builder;
+
+import java.time.Instant;
+
+/**
+ * Command representing a soft delete of an existing link instance.
+ */
+@Builder
+public record DeleteAssetLinkCommand(
+        String assetId,
+        String linkId,
+        String requestedBy,
+        Instant requestTime
+) {
+}

--- a/src/main/java/com/db/assetstore/domain/service/link/cmd/PatchAssetLinkCommand.java
+++ b/src/main/java/com/db/assetstore/domain/service/link/cmd/PatchAssetLinkCommand.java
@@ -1,0 +1,23 @@
+package com.db.assetstore.domain.service.link.cmd;
+
+import lombok.Builder;
+
+import java.time.Instant;
+
+/**
+ * Command describing partial updates to an existing asset link.
+ */
+@Builder
+public record PatchAssetLinkCommand(
+        String assetId,
+        String linkId,
+        Boolean active,
+        Instant validFrom,
+        Instant validTo,
+        String requestedBy,
+        Instant requestTime
+) {
+    public boolean hasActiveChange() {
+        return active != null;
+    }
+}

--- a/src/main/java/com/db/assetstore/domain/service/link/cmd/factory/AssetLinkCommandFactory.java
+++ b/src/main/java/com/db/assetstore/domain/service/link/cmd/factory/AssetLinkCommandFactory.java
@@ -1,0 +1,61 @@
+package com.db.assetstore.domain.service.link.cmd.factory;
+
+import com.db.assetstore.domain.service.link.cmd.CreateAssetLinkCommand;
+import com.db.assetstore.domain.service.link.cmd.DeleteAssetLinkCommand;
+import com.db.assetstore.domain.service.link.cmd.PatchAssetLinkCommand;
+import com.db.assetstore.infra.api.dto.AssetLinkCreateRequest;
+import com.db.assetstore.infra.api.dto.AssetLinkPatchRequest;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Factory translating transport DTOs into command objects for asset links.
+ */
+@Component
+public class AssetLinkCommandFactory {
+
+    public CreateAssetLinkCommand createCommand(String assetId, AssetLinkCreateRequest request) {
+        Objects.requireNonNull(assetId, "assetId");
+        Objects.requireNonNull(request, "request");
+        return CreateAssetLinkCommand.builder()
+                .assetId(assetId)
+                .linkCode(request.getLinkCode())
+                .linkSubtype(request.getLinkSubtype())
+                .entityType(request.getEntityType())
+                .entityId(request.getEntityId())
+                .active(request.getActive())
+                .validFrom(request.getValidFrom())
+                .validTo(request.getValidTo())
+                .requestedBy(request.getRequestedBy())
+                .requestTime(Instant.now())
+                .build();
+    }
+
+    public DeleteAssetLinkCommand deleteCommand(String assetId, String linkId, String requestedBy) {
+        Objects.requireNonNull(assetId, "assetId");
+        Objects.requireNonNull(linkId, "linkId");
+        return DeleteAssetLinkCommand.builder()
+                .assetId(assetId)
+                .linkId(linkId)
+                .requestedBy(requestedBy)
+                .requestTime(Instant.now())
+                .build();
+    }
+
+    public PatchAssetLinkCommand patchCommand(String assetId, String linkId, AssetLinkPatchRequest request) {
+        Objects.requireNonNull(assetId, "assetId");
+        Objects.requireNonNull(linkId, "linkId");
+        Objects.requireNonNull(request, "request");
+        return PatchAssetLinkCommand.builder()
+                .assetId(assetId)
+                .linkId(linkId)
+                .active(request.getActive())
+                .validFrom(request.getValidFrom())
+                .validTo(request.getValidTo())
+                .requestedBy(request.getRequestedBy())
+                .requestTime(Instant.now())
+                .build();
+    }
+}

--- a/src/main/java/com/db/assetstore/infra/api/AssetLinkController.java
+++ b/src/main/java/com/db/assetstore/infra/api/AssetLinkController.java
@@ -1,0 +1,57 @@
+package com.db.assetstore.infra.api;
+
+import com.db.assetstore.domain.model.link.AssetLink;
+import com.db.assetstore.domain.service.AssetCommandService;
+import com.db.assetstore.domain.service.AssetQueryService;
+import com.db.assetstore.domain.service.link.cmd.factory.AssetLinkCommandFactory;
+import com.db.assetstore.infra.api.dto.AssetLinkCreateRequest;
+import com.db.assetstore.infra.api.dto.AssetLinkPatchRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/assets/{assetId}/links")
+@RequiredArgsConstructor
+public class AssetLinkController {
+
+    private final AssetCommandService commandService;
+    private final AssetQueryService queryService;
+    private final AssetLinkCommandFactory commandFactory;
+
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> create(@PathVariable("assetId") String assetId,
+                                         @RequestBody AssetLinkCreateRequest request) {
+        var command = commandFactory.createCommand(assetId, request);
+        String id = commandService.createLink(command);
+        return ResponseEntity.ok(id);
+    }
+
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<List<AssetLink>> list(@PathVariable("assetId") String assetId,
+                                                @RequestParam(name = "activeOnly", defaultValue = "false") boolean activeOnly) {
+        List<AssetLink> links = queryService.findLinksByAsset(assetId, activeOnly);
+        return ResponseEntity.ok(links);
+    }
+
+    @DeleteMapping(path = "/{linkId}")
+    public ResponseEntity<Void> delete(@PathVariable("assetId") String assetId,
+                                       @PathVariable("linkId") String linkId,
+                                       @RequestParam(name = "requestedBy", required = false) String requestedBy) {
+        var command = commandFactory.deleteCommand(assetId, linkId, requestedBy);
+        commandService.deleteLink(command);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping(path = "/{linkId}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Void> patch(@PathVariable("assetId") String assetId,
+                                      @PathVariable("linkId") String linkId,
+                                      @RequestBody AssetLinkPatchRequest request) {
+        var command = commandFactory.patchCommand(assetId, linkId, request);
+        commandService.patchLink(command);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/db/assetstore/infra/api/AssetLinkQueryController.java
+++ b/src/main/java/com/db/assetstore/infra/api/AssetLinkQueryController.java
@@ -1,0 +1,29 @@
+package com.db.assetstore.infra.api;
+
+import com.db.assetstore.domain.model.link.AssetLink;
+import com.db.assetstore.domain.service.AssetQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/links")
+@RequiredArgsConstructor
+public class AssetLinkQueryController {
+
+    private final AssetQueryService queryService;
+
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<List<AssetLink>> findByEntity(@RequestParam("entityType") String entityType,
+                                                        @RequestParam("entityId") String entityId,
+                                                        @RequestParam(name = "activeOnly", defaultValue = "false") boolean activeOnly) {
+        List<AssetLink> links = queryService.findLinksByEntity(entityType, entityId, activeOnly);
+        return ResponseEntity.ok(links);
+    }
+}

--- a/src/main/java/com/db/assetstore/infra/api/dto/AssetLinkCreateRequest.java
+++ b/src/main/java/com/db/assetstore/infra/api/dto/AssetLinkCreateRequest.java
@@ -1,0 +1,24 @@
+package com.db.assetstore.infra.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+
+/**
+ * HTTP payload used to create a new asset link instance.
+ */
+@Getter
+@Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AssetLinkCreateRequest {
+    private String linkCode;
+    private String linkSubtype;
+    private String entityType;
+    private String entityId;
+    private Boolean active;
+    private Instant validFrom;
+    private Instant validTo;
+    private String requestedBy;
+}

--- a/src/main/java/com/db/assetstore/infra/api/dto/AssetLinkPatchRequest.java
+++ b/src/main/java/com/db/assetstore/infra/api/dto/AssetLinkPatchRequest.java
@@ -1,0 +1,20 @@
+package com.db.assetstore.infra.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+
+/**
+ * HTTP payload used to patch an existing asset link instance.
+ */
+@Getter
+@Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AssetLinkPatchRequest {
+    private Boolean active;
+    private Instant validFrom;
+    private Instant validTo;
+    private String requestedBy;
+}

--- a/src/main/java/com/db/assetstore/infra/jpa/link/AssetLinkEntity.java
+++ b/src/main/java/com/db/assetstore/infra/jpa/link/AssetLinkEntity.java
@@ -1,0 +1,59 @@
+package com.db.assetstore.infra.jpa.link;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "asset_link")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class AssetLinkEntity {
+
+    @Id
+    @Column(name = "id", length = 36, nullable = false)
+    private String id;
+
+    @Column(name = "asset_id", length = 36, nullable = false)
+    private String assetId;
+
+    @Column(name = "link_code", length = 64, nullable = false)
+    private String linkCode;
+
+    @Column(name = "link_subtype", length = 64, nullable = false)
+    private String linkSubtype;
+
+    @Column(name = "entity_type", length = 64, nullable = false)
+    private String entityType;
+
+    @Column(name = "entity_id", length = 128, nullable = false)
+    private String entityId;
+
+    @Column(name = "active", nullable = false)
+    private boolean active;
+
+    @Column(name = "deleted", nullable = false)
+    private boolean deleted;
+
+    @Column(name = "valid_from")
+    private Instant validFrom;
+
+    @Column(name = "valid_to")
+    private Instant validTo;
+
+    @Column(name = "created_at")
+    private Instant createdAt;
+
+    @Column(name = "created_by", length = 64)
+    private String createdBy;
+
+    @Column(name = "modified_at")
+    private Instant modifiedAt;
+
+    @Column(name = "modified_by", length = 64)
+    private String modifiedBy;
+}

--- a/src/main/java/com/db/assetstore/infra/jpa/link/LinkDefinitionEntity.java
+++ b/src/main/java/com/db/assetstore/infra/jpa/link/LinkDefinitionEntity.java
@@ -1,0 +1,36 @@
+package com.db.assetstore.infra.jpa.link;
+
+import com.db.assetstore.domain.model.link.LinkCardinality;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "link_definition")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class LinkDefinitionEntity {
+
+    @Id
+    @Column(name = "code", length = 64, nullable = false)
+    private String code;
+
+    @Column(name = "entity_type", length = 64, nullable = false)
+    private String entityType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "cardinality", length = 32, nullable = false)
+    private LinkCardinality cardinality;
+
+    @Column(name = "is_enabled", nullable = false)
+    private boolean enabled;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "definition", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private Set<LinkSubtypeDefinitionEntity> subtypes = new HashSet<>();
+}

--- a/src/main/java/com/db/assetstore/infra/jpa/link/LinkSubtypeDefinitionEntity.java
+++ b/src/main/java/com/db/assetstore/infra/jpa/link/LinkSubtypeDefinitionEntity.java
@@ -1,0 +1,22 @@
+package com.db.assetstore.infra.jpa.link;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "link_subtype_def")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class LinkSubtypeDefinitionEntity {
+
+    @EmbeddedId
+    private LinkSubtypeDefinitionId id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("code")
+    @JoinColumn(name = "code", nullable = false)
+    private LinkDefinitionEntity definition;
+}

--- a/src/main/java/com/db/assetstore/infra/jpa/link/LinkSubtypeDefinitionId.java
+++ b/src/main/java/com/db/assetstore/infra/jpa/link/LinkSubtypeDefinitionId.java
@@ -1,0 +1,30 @@
+package com.db.assetstore.infra.jpa.link;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Embeddable
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class LinkSubtypeDefinitionId implements Serializable {
+
+    @Column(name = "code", length = 64, nullable = false)
+    private String code;
+
+    @Column(name = "subtype", length = 64, nullable = false)
+    private String subtype;
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getSubtype() {
+        return subtype;
+    }
+}

--- a/src/main/java/com/db/assetstore/infra/mapper/AssetLinkMapper.java
+++ b/src/main/java/com/db/assetstore/infra/mapper/AssetLinkMapper.java
@@ -1,0 +1,46 @@
+package com.db.assetstore.infra.mapper;
+
+import com.db.assetstore.domain.model.link.AssetLink;
+import com.db.assetstore.infra.jpa.link.AssetLinkEntity;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Component
+public class AssetLinkMapper {
+
+    public AssetLink toModel(AssetLinkEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+        return AssetLink.builder()
+                .id(entity.getId())
+                .assetId(entity.getAssetId())
+                .linkCode(entity.getLinkCode())
+                .linkSubtype(entity.getLinkSubtype())
+                .entityType(entity.getEntityType())
+                .entityId(entity.getEntityId())
+                .active(entity.isActive())
+                .deleted(entity.isDeleted())
+                .validFrom(entity.getValidFrom())
+                .validTo(entity.getValidTo())
+                .createdAt(entity.getCreatedAt())
+                .createdBy(entity.getCreatedBy())
+                .modifiedAt(entity.getModifiedAt())
+                .modifiedBy(entity.getModifiedBy())
+                .build();
+    }
+
+    public List<AssetLink> toModels(Collection<AssetLinkEntity> entities) {
+        if (entities == null) {
+            return List.of();
+        }
+        return entities.stream()
+                .filter(Objects::nonNull)
+                .map(this::toModel)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/db/assetstore/infra/repository/link/AssetLinkRepository.java
+++ b/src/main/java/com/db/assetstore/infra/repository/link/AssetLinkRepository.java
@@ -1,0 +1,26 @@
+package com.db.assetstore.infra.repository.link;
+
+import com.db.assetstore.infra.jpa.link.AssetLinkEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AssetLinkRepository extends JpaRepository<AssetLinkEntity, String> {
+
+    List<AssetLinkEntity> findByAssetIdAndDeleted(String assetId, boolean deleted);
+
+    List<AssetLinkEntity> findByAssetIdAndActiveAndDeleted(String assetId, boolean active, boolean deleted);
+
+    List<AssetLinkEntity> findByEntityTypeAndEntityIdAndDeleted(String entityType, String entityId, boolean deleted);
+
+    List<AssetLinkEntity> findByEntityTypeAndEntityIdAndActiveAndDeleted(String entityType, String entityId, boolean active, boolean deleted);
+
+    long countByAssetIdAndLinkCodeAndLinkSubtypeAndActiveIsTrueAndDeletedIsFalse(String assetId, String linkCode, String linkSubtype);
+
+    long countByEntityTypeAndEntityIdAndLinkCodeAndLinkSubtypeAndActiveIsTrueAndDeletedIsFalse(String entityType, String entityId, String linkCode, String linkSubtype);
+
+    boolean existsByAssetIdAndEntityTypeAndEntityIdAndLinkCodeAndLinkSubtypeAndDeletedIsFalse(String assetId, String entityType, String entityId, String linkCode, String linkSubtype);
+
+    Optional<AssetLinkEntity> findByIdAndDeletedIsFalse(String id);
+}

--- a/src/main/java/com/db/assetstore/infra/repository/link/LinkDefinitionRepository.java
+++ b/src/main/java/com/db/assetstore/infra/repository/link/LinkDefinitionRepository.java
@@ -1,0 +1,16 @@
+package com.db.assetstore.infra.repository.link;
+
+import com.db.assetstore.infra.jpa.link.LinkDefinitionEntity;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LinkDefinitionRepository extends JpaRepository<LinkDefinitionEntity, String> {
+
+    @EntityGraph(attributePaths = "subtypes")
+    Optional<LinkDefinitionEntity> findByCode(String code);
+
+    @EntityGraph(attributePaths = "subtypes")
+    Optional<LinkDefinitionEntity> findByCodeIgnoreCase(String code);
+}

--- a/src/main/java/com/db/assetstore/infra/service/AssetCommandServiceImpl.java
+++ b/src/main/java/com/db/assetstore/infra/service/AssetCommandServiceImpl.java
@@ -1,18 +1,27 @@
 package com.db.assetstore.infra.service;
 
-import com.db.assetstore.domain.service.cmd.CreateAssetCommand;
-import com.db.assetstore.domain.service.cmd.PatchAssetCommand;
 import com.db.assetstore.domain.model.Asset;
 import com.db.assetstore.domain.model.AssetPatch;
 import com.db.assetstore.domain.model.attribute.AttributeValue;
 import com.db.assetstore.domain.model.attribute.AttributesCollection;
+import com.db.assetstore.domain.model.link.LinkCardinality;
+import com.db.assetstore.domain.service.cmd.CreateAssetCommand;
+import com.db.assetstore.domain.service.cmd.PatchAssetCommand;
+import com.db.assetstore.domain.service.link.cmd.CreateAssetLinkCommand;
+import com.db.assetstore.domain.service.link.cmd.DeleteAssetLinkCommand;
+import com.db.assetstore.domain.service.link.cmd.PatchAssetLinkCommand;
 import com.db.assetstore.domain.service.AssetCommandService;
 import com.db.assetstore.infra.jpa.AssetEntity;
 import com.db.assetstore.infra.jpa.AttributeEntity;
+import com.db.assetstore.infra.jpa.link.AssetLinkEntity;
+import com.db.assetstore.infra.jpa.link.LinkDefinitionEntity;
+import com.db.assetstore.infra.jpa.link.LinkSubtypeDefinitionEntity;
 import com.db.assetstore.infra.mapper.AssetMapper;
 import com.db.assetstore.infra.mapper.AttributeMapper;
 import com.db.assetstore.infra.repository.AssetRepository;
 import com.db.assetstore.infra.repository.AttributeRepository;
+import com.db.assetstore.infra.repository.link.AssetLinkRepository;
+import com.db.assetstore.infra.repository.link.LinkDefinitionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -34,6 +43,8 @@ public class AssetCommandServiceImpl implements AssetCommandService {
     private final AttributeMapper attributeMapper;
     private final AssetRepository assetRepo;
     private final AttributeRepository attributeRepo;
+    private final AssetLinkRepository assetLinkRepository;
+    private final LinkDefinitionRepository linkDefinitionRepository;
 
     @Override
     @Transactional
@@ -119,6 +130,87 @@ public class AssetCommandServiceImpl implements AssetCommandService {
         assetRepo.save(e);
     }
 
+    @Override
+    @Transactional
+    public String createLink(CreateAssetLinkCommand command) {
+        Objects.requireNonNull(command, "command");
+        AssetEntity asset = assetRepo.findByIdAndDeleted(command.assetId(), 0)
+                .orElseThrow(() -> new IllegalArgumentException("Asset not found: " + command.assetId()));
+
+        LinkDefinitionEntity definition = linkDefinitionRepository.findByCodeIgnoreCase(command.linkCode())
+                .orElseThrow(() -> new IllegalArgumentException("Unknown link code: " + command.linkCode()));
+
+        validateDefinition(definition, command);
+        if (command.shouldActivate()) {
+            validateCardinality(definition, command);
+        }
+
+        if (assetLinkRepository.existsByAssetIdAndEntityTypeAndEntityIdAndLinkCodeAndLinkSubtypeAndDeletedIsFalse(
+                asset.getId(), command.entityType(), command.entityId(), definition.getCode(), command.linkSubtype())) {
+            throw new IllegalStateException("Link already exists for asset %s and entity %s".formatted(asset.getId(), command.entityId()));
+        }
+
+        AssetLinkEntity entity = buildLinkEntity(asset.getId(), definition.getCode(), command);
+        assetLinkRepository.save(entity);
+        return entity.getId();
+    }
+
+    @Override
+    @Transactional
+    public void deleteLink(DeleteAssetLinkCommand command) {
+        Objects.requireNonNull(command, "command");
+        AssetLinkEntity entity = assetLinkRepository.findByIdAndDeletedIsFalse(command.linkId())
+                .orElseThrow(() -> new IllegalArgumentException("Asset link not found: " + command.linkId()));
+        if (!entity.getAssetId().equals(command.assetId())) {
+            throw new IllegalArgumentException("Link %s does not belong to asset %s".formatted(command.linkId(), command.assetId()));
+        }
+        Instant now = Optional.ofNullable(command.requestTime()).orElseGet(Instant::now);
+        entity.setActive(false);
+        entity.setDeleted(true);
+        entity.setValidTo(now);
+        entity.setModifiedAt(now);
+        entity.setModifiedBy(command.requestedBy());
+        assetLinkRepository.save(entity);
+    }
+
+    @Override
+    @Transactional
+    public void patchLink(PatchAssetLinkCommand command) {
+        Objects.requireNonNull(command, "command");
+
+        AssetLinkEntity entity = assetLinkRepository.findByIdAndDeletedIsFalse(command.linkId())
+                .orElseThrow(() -> new IllegalArgumentException("Asset link not found: " + command.linkId()));
+        if (!entity.getAssetId().equals(command.assetId())) {
+            throw new IllegalArgumentException("Link %s does not belong to asset %s".formatted(command.linkId(), command.assetId()));
+        }
+
+        Instant now = Optional.ofNullable(command.requestTime()).orElseGet(Instant::now);
+
+        if (command.hasActiveChange() && command.active() != entity.isActive()) {
+            if (Boolean.TRUE.equals(command.active())) {
+                LinkDefinitionEntity definition = linkDefinitionRepository.findByCodeIgnoreCase(entity.getLinkCode())
+                        .orElseThrow(() -> new IllegalStateException("Link definition not found for code: " + entity.getLinkCode()));
+                validateDefinition(definition, entity.getEntityType(), entity.getEntityId(), entity.getLinkSubtype());
+                validateCardinality(definition, entity.getAssetId(), entity.getEntityType(), entity.getEntityId(), entity.getLinkSubtype());
+                entity.setActive(true);
+                entity.setDeleted(false);
+            } else {
+                entity.setActive(false);
+            }
+        }
+
+        if (command.validFrom() != null) {
+            entity.setValidFrom(command.validFrom());
+        }
+        if (command.validTo() != null) {
+            entity.setValidTo(command.validTo());
+        }
+
+        entity.setModifiedAt(now);
+        entity.setModifiedBy(command.requestedBy());
+        assetLinkRepository.save(entity);
+    }
+
     private void updateAsset(AssetEntity asset, Collection<AttributeValue<?>> attributes) {
         Objects.requireNonNull(asset, "asset entity");
         Objects.requireNonNull(attributes, "attributes");
@@ -158,5 +250,90 @@ public class AssetCommandServiceImpl implements AssetCommandService {
             }
         }
         assetRepo.save(asset);
+    }
+
+    private void validateDefinition(LinkDefinitionEntity definition, CreateAssetLinkCommand command) {
+        validateDefinition(definition, command.entityType(), command.entityId(), command.linkSubtype());
+    }
+
+    private void validateDefinition(LinkDefinitionEntity definition, String entityType, String entityId, String linkSubtype) {
+        if (!definition.isEnabled()) {
+            throw new IllegalStateException("Link definition %s is disabled".formatted(definition.getCode()));
+        }
+        if (entityType == null || entityType.isBlank()) {
+            throw new IllegalArgumentException("Entity type must be provided");
+        }
+        if (entityId == null || entityId.isBlank()) {
+            throw new IllegalArgumentException("Entity id must be provided");
+        }
+        if (!definition.getEntityType().equalsIgnoreCase(entityType)) {
+            throw new IllegalArgumentException("Entity type %s not allowed for link %s".formatted(entityType, definition.getCode()));
+        }
+        if (linkSubtype == null || linkSubtype.isBlank()) {
+            throw new IllegalArgumentException("Link subtype must be provided");
+        }
+        var subtypes = definition.getSubtypes();
+        if (subtypes == null || subtypes.isEmpty()) {
+            throw new IllegalStateException("No subtypes configured for link %s".formatted(definition.getCode()));
+        }
+        boolean subtypeAllowed = subtypes.stream()
+                .map(LinkSubtypeDefinitionEntity::getId)
+                .map(id -> id.getSubtype().toUpperCase())
+                .anyMatch(code -> code.equalsIgnoreCase(linkSubtype));
+        if (!subtypeAllowed) {
+            throw new IllegalArgumentException("Subtype %s not allowed for link %s".formatted(linkSubtype, definition.getCode()));
+        }
+    }
+
+    private void validateCardinality(LinkDefinitionEntity definition, CreateAssetLinkCommand command) {
+        validateCardinality(definition, command.assetId(), command.entityType(), command.entityId(), command.linkSubtype());
+    }
+
+    private void validateCardinality(LinkDefinitionEntity definition, String assetId, String entityType, String entityId, String linkSubtype) {
+        LinkCardinality cardinality = definition.getCardinality();
+        long assetActive = assetLinkRepository.countByAssetIdAndLinkCodeAndLinkSubtypeAndActiveIsTrueAndDeletedIsFalse(
+                assetId, definition.getCode(), linkSubtype);
+        long entityActive = assetLinkRepository.countByEntityTypeAndEntityIdAndLinkCodeAndLinkSubtypeAndActiveIsTrueAndDeletedIsFalse(
+                entityType, entityId, definition.getCode(), linkSubtype);
+        switch (cardinality) {
+            case ONE_TO_ONE -> {
+                if (assetActive > 0 || entityActive > 0) {
+                    throw new IllegalStateException("ONE_TO_ONE link already exists for asset %s or entity %s".formatted(assetId, entityId));
+                }
+            }
+            case ONE_TO_MANY -> {
+                if (entityActive > 0) {
+                    throw new IllegalStateException("Entity %s already linked for ONE_TO_MANY".formatted(entityId));
+                }
+            }
+            case MANY_TO_ONE -> {
+                if (assetActive > 0) {
+                    throw new IllegalStateException("Asset %s already linked for MANY_TO_ONE".formatted(assetId));
+                }
+            }
+            default -> throw new IllegalStateException("Unsupported cardinality: " + cardinality);
+        }
+    }
+
+    private AssetLinkEntity buildLinkEntity(String assetId, String linkCode, CreateAssetLinkCommand command) {
+        Instant now = Optional.ofNullable(command.requestTime()).orElseGet(Instant::now);
+        Instant validFrom = Optional.ofNullable(command.validFrom()).orElse(now);
+        boolean active = command.shouldActivate();
+        return AssetLinkEntity.builder()
+                .id(UUID.randomUUID().toString())
+                .assetId(assetId)
+                .linkCode(linkCode)
+                .linkSubtype(command.linkSubtype())
+                .entityType(command.entityType())
+                .entityId(command.entityId())
+                .active(active)
+                .deleted(false)
+                .validFrom(validFrom)
+                .validTo(command.validTo())
+                .createdAt(now)
+                .createdBy(command.requestedBy())
+                .modifiedAt(now)
+                .modifiedBy(command.requestedBy())
+                .build();
     }
 }

--- a/src/main/java/com/db/assetstore/infra/service/AssetQueryServiceImpl.java
+++ b/src/main/java/com/db/assetstore/infra/service/AssetQueryServiceImpl.java
@@ -1,11 +1,15 @@
 package com.db.assetstore.infra.service;
 
 import com.db.assetstore.domain.model.Asset;
+import com.db.assetstore.domain.model.link.AssetLink;
 import com.db.assetstore.domain.service.AssetQueryService;
 import com.db.assetstore.domain.search.SearchCriteria;
 import com.db.assetstore.infra.jpa.AssetEntity;
+import com.db.assetstore.infra.jpa.link.AssetLinkEntity;
 import com.db.assetstore.infra.mapper.AssetMapper;
+import com.db.assetstore.infra.mapper.AssetLinkMapper;
 import com.db.assetstore.infra.repository.AssetRepository;
+import com.db.assetstore.infra.repository.link.AssetLinkRepository;
 import com.db.assetstore.infra.service.search.AssetSearchSpecificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,6 +25,8 @@ public class AssetQueryServiceImpl implements AssetQueryService {
     private final AssetMapper assetMapper;
     private final AssetRepository assetRepo;
     private final AssetSearchSpecificationService specService;
+    private final AssetLinkRepository assetLinkRepository;
+    private final AssetLinkMapper assetLinkMapper;
 
     @Override
     @Transactional(readOnly = true)
@@ -33,6 +39,24 @@ public class AssetQueryServiceImpl implements AssetQueryService {
     public List<Asset> search(SearchCriteria criteria) {
         List<AssetEntity> entities = searchEntities(criteria);
         return assetMapper.toModelList(entities);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AssetLink> findLinksByAsset(String assetId, boolean activeOnly) {
+        List<AssetLinkEntity> entities = activeOnly
+                ? assetLinkRepository.findByAssetIdAndActiveAndDeleted(assetId, true, false)
+                : assetLinkRepository.findByAssetIdAndDeleted(assetId, false);
+        return assetLinkMapper.toModels(entities);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AssetLink> findLinksByEntity(String entityType, String entityId, boolean activeOnly) {
+        List<AssetLinkEntity> entities = activeOnly
+                ? assetLinkRepository.findByEntityTypeAndEntityIdAndActiveAndDeleted(entityType, entityId, true, false)
+                : assetLinkRepository.findByEntityTypeAndEntityIdAndDeleted(entityType, entityId, false);
+        return assetLinkMapper.toModels(entities);
     }
 
     private List<AssetEntity> searchEntities(SearchCriteria criteria) {

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -122,4 +122,132 @@
         </addColumn>
         <dropColumn tableName="asset_attribute_history" columnName="attr_value"/>
     </changeSet>
+
+    <changeSet id="7-link-definition" author="junie">
+        <createTable tableName="link_definition">
+            <column name="code" type="varchar(64)">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="entity_type" type="varchar(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cardinality" type="varchar(32)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="is_enabled" type="boolean" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="8-link-subtype-definition" author="junie">
+        <createTable tableName="link_subtype_def">
+            <column name="code" type="varchar(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="subtype" type="varchar(64)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addPrimaryKey tableName="link_subtype_def" columnNames="code, subtype" constraintName="pk_link_subtype_def"/>
+        <addForeignKeyConstraint baseTableName="link_subtype_def"
+                                 baseColumnNames="code"
+                                 referencedTableName="link_definition"
+                                 referencedColumnNames="code"
+                                 constraintName="fk_link_subtype_def"/>
+    </changeSet>
+
+    <changeSet id="9-asset-link" author="junie">
+        <createTable tableName="asset_link">
+            <column name="id" type="varchar(36)">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="asset_id" type="varchar(36)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="link_code" type="varchar(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="link_subtype" type="varchar(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="entity_type" type="varchar(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="entity_id" type="varchar(128)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="active" type="boolean" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+            <column name="deleted" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+            <column name="valid_from" type="timestamp"/>
+            <column name="valid_to" type="timestamp"/>
+            <column name="created_at" type="timestamp"/>
+            <column name="created_by" type="varchar(64)"/>
+            <column name="modified_at" type="timestamp"/>
+            <column name="modified_by" type="varchar(64)"/>
+        </createTable>
+        <addForeignKeyConstraint baseTableName="asset_link"
+                                 baseColumnNames="asset_id"
+                                 referencedTableName="assets"
+                                 referencedColumnNames="id"
+                                 constraintName="fk_asset_link_asset"/>
+        <addForeignKeyConstraint baseTableName="asset_link"
+                                 baseColumnNames="link_code"
+                                 referencedTableName="link_definition"
+                                 referencedColumnNames="code"
+                                 constraintName="fk_asset_link_definition"/>
+    </changeSet>
+
+    <changeSet id="10-link-definition-seed" author="junie">
+        <insert tableName="link_definition">
+            <column name="code" value="WORKFLOW"/>
+            <column name="entity_type" value="WORKFLOW"/>
+            <column name="cardinality" value="ONE_TO_ONE"/>
+            <column name="is_enabled" valueBoolean="true"/>
+        </insert>
+        <insert tableName="link_definition">
+            <column name="code" value="INSTRUMENT"/>
+            <column name="entity_type" value="INSTRUMENT"/>
+            <column name="cardinality" value="MANY_TO_ONE"/>
+            <column name="is_enabled" valueBoolean="true"/>
+        </insert>
+
+        <insert tableName="link_subtype_def">
+            <column name="code" value="WORKFLOW"/>
+            <column name="subtype" value="BULK"/>
+        </insert>
+        <insert tableName="link_subtype_def">
+            <column name="code" value="WORKFLOW"/>
+            <column name="subtype" value="MONITORING"/>
+        </insert>
+        <insert tableName="link_subtype_def">
+            <column name="code" value="WORKFLOW"/>
+            <column name="subtype" value="REVALUATION"/>
+        </insert>
+        <insert tableName="link_subtype_def">
+            <column name="code" value="WORKFLOW"/>
+            <column name="subtype" value="CHG"/>
+        </insert>
+
+        <insert tableName="link_subtype_def">
+            <column name="code" value="INSTRUMENT"/>
+            <column name="subtype" value="BULK"/>
+        </insert>
+        <insert tableName="link_subtype_def">
+            <column name="code" value="INSTRUMENT"/>
+            <column name="subtype" value="MONITORING"/>
+        </insert>
+        <insert tableName="link_subtype_def">
+            <column name="code" value="INSTRUMENT"/>
+            <column name="subtype" value="REVALUATION"/>
+        </insert>
+        <insert tableName="link_subtype_def">
+            <column name="code" value="INSTRUMENT"/>
+            <column name="subtype" value="CHG"/>
+        </insert>
+    </changeSet>
 </databaseChangeLog>

--- a/src/test/java/com/db/assetstore/service/AssetCommandServiceImplLinkTest.java
+++ b/src/test/java/com/db/assetstore/service/AssetCommandServiceImplLinkTest.java
@@ -1,0 +1,240 @@
+package com.db.assetstore.service;
+
+import com.db.assetstore.domain.model.link.LinkCardinality;
+import com.db.assetstore.domain.service.link.cmd.CreateAssetLinkCommand;
+import com.db.assetstore.domain.service.link.cmd.DeleteAssetLinkCommand;
+import com.db.assetstore.domain.service.link.cmd.PatchAssetLinkCommand;
+import com.db.assetstore.infra.jpa.AssetEntity;
+import com.db.assetstore.infra.jpa.link.AssetLinkEntity;
+import com.db.assetstore.infra.jpa.link.LinkDefinitionEntity;
+import com.db.assetstore.infra.jpa.link.LinkSubtypeDefinitionEntity;
+import com.db.assetstore.infra.jpa.link.LinkSubtypeDefinitionId;
+import com.db.assetstore.infra.mapper.AssetMapper;
+import com.db.assetstore.infra.mapper.AttributeMapper;
+import com.db.assetstore.infra.repository.AssetRepository;
+import com.db.assetstore.infra.repository.AttributeRepository;
+import com.db.assetstore.infra.repository.link.AssetLinkRepository;
+import com.db.assetstore.infra.repository.link.LinkDefinitionRepository;
+import com.db.assetstore.infra.service.AssetCommandServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class AssetCommandServiceImplLinkTest {
+
+    AssetRepository assetRepository;
+    AttributeRepository attributeRepository;
+    AssetLinkRepository assetLinkRepository;
+    LinkDefinitionRepository linkDefinitionRepository;
+    AssetMapper assetMapper;
+    AttributeMapper attributeMapper;
+
+    AssetCommandServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        assetRepository = mock(AssetRepository.class);
+        attributeRepository = mock(AttributeRepository.class);
+        assetLinkRepository = mock(AssetLinkRepository.class);
+        linkDefinitionRepository = mock(LinkDefinitionRepository.class);
+        assetMapper = mock(AssetMapper.class);
+        attributeMapper = mock(AttributeMapper.class);
+        service = new AssetCommandServiceImpl(assetMapper, attributeMapper, assetRepository, attributeRepository, assetLinkRepository, linkDefinitionRepository);
+    }
+
+    @Test
+    void create_whenDefinitionDisabled_shouldThrow() {
+        CreateAssetLinkCommand command = CreateAssetLinkCommand.builder()
+                .assetId("A1")
+                .linkCode("WORKFLOW")
+                .linkSubtype("BULK")
+                .entityType("WORKFLOW")
+                .entityId("WF-1")
+                .build();
+
+        AssetEntity asset = AssetEntity.builder().id("A1").build();
+        when(assetRepository.findByIdAndDeleted("A1", 0)).thenReturn(Optional.of(asset));
+        LinkDefinitionEntity definition = LinkDefinitionEntity.builder()
+                .code("WORKFLOW")
+                .entityType("WORKFLOW")
+                .cardinality(LinkCardinality.ONE_TO_ONE)
+                .enabled(false)
+                .build();
+        definition.setSubtypes(Set.of(buildSubtype(definition, "BULK")));
+        when(linkDefinitionRepository.findByCodeIgnoreCase("WORKFLOW")).thenReturn(Optional.of(definition));
+
+        assertThrows(IllegalStateException.class, () -> service.createLink(command));
+    }
+
+    @Test
+    void create_oneToOneExistingLink_shouldThrow() {
+        CreateAssetLinkCommand command = CreateAssetLinkCommand.builder()
+                .assetId("A1")
+                .linkCode("WORKFLOW")
+                .linkSubtype("BULK")
+                .entityType("WORKFLOW")
+                .entityId("WF-1")
+                .build();
+
+        AssetEntity asset = AssetEntity.builder().id("A1").build();
+        when(assetRepository.findByIdAndDeleted("A1", 0)).thenReturn(Optional.of(asset));
+        LinkDefinitionEntity definition = LinkDefinitionEntity.builder()
+                .code("WORKFLOW")
+                .entityType("WORKFLOW")
+                .cardinality(LinkCardinality.ONE_TO_ONE)
+                .enabled(true)
+                .build();
+        definition.setSubtypes(Set.of(buildSubtype(definition, "BULK")));
+        when(linkDefinitionRepository.findByCodeIgnoreCase("WORKFLOW")).thenReturn(Optional.of(definition));
+        when(assetLinkRepository.countByAssetIdAndLinkCodeAndLinkSubtypeAndActiveIsTrueAndDeletedIsFalse("A1", "WORKFLOW", "BULK"))
+                .thenReturn(1L);
+
+        assertThrows(IllegalStateException.class, () -> service.createLink(command));
+    }
+
+    @Test
+    void create_success_savesLink() {
+        CreateAssetLinkCommand command = CreateAssetLinkCommand.builder()
+                .assetId("A1")
+                .linkCode("WORKFLOW")
+                .linkSubtype("BULK")
+                .entityType("WORKFLOW")
+                .entityId("WF-1")
+                .requestedBy("tester")
+                .requestTime(Instant.parse("2024-01-01T00:00:00Z"))
+                .build();
+
+        AssetEntity asset = AssetEntity.builder().id("A1").build();
+        when(assetRepository.findByIdAndDeleted("A1", 0)).thenReturn(Optional.of(asset));
+        LinkDefinitionEntity definition = LinkDefinitionEntity.builder()
+                .code("WORKFLOW")
+                .entityType("WORKFLOW")
+                .cardinality(LinkCardinality.MANY_TO_ONE)
+                .enabled(true)
+                .build();
+        definition.setSubtypes(Set.of(buildSubtype(definition, "BULK")));
+        when(linkDefinitionRepository.findByCodeIgnoreCase("WORKFLOW")).thenReturn(Optional.of(definition));
+        when(assetLinkRepository.existsByAssetIdAndEntityTypeAndEntityIdAndLinkCodeAndLinkSubtypeAndDeletedIsFalse(any(), any(), any(), any(), any()))
+                .thenReturn(false);
+
+        ArgumentCaptor<AssetLinkEntity> entityCaptor = ArgumentCaptor.forClass(AssetLinkEntity.class);
+
+        String id = service.createLink(command);
+
+        assertNotNull(id);
+        verify(assetLinkRepository, times(1)).save(entityCaptor.capture());
+        assertEquals(id, entityCaptor.getValue().getId());
+    }
+
+    @Test
+    void delete_marksLinkInactive() {
+        DeleteAssetLinkCommand command = DeleteAssetLinkCommand.builder()
+                .assetId("A1")
+                .linkId("L1")
+                .requestedBy("tester")
+                .requestTime(Instant.parse("2024-01-01T00:00:00Z"))
+                .build();
+
+        AssetLinkEntity entity = AssetLinkEntity.builder()
+                .id("L1")
+                .assetId("A1")
+                .active(true)
+                .deleted(false)
+                .build();
+
+        when(assetLinkRepository.findByIdAndDeletedIsFalse("L1")).thenReturn(Optional.of(entity));
+
+        service.deleteLink(command);
+
+        assertFalse(entity.isActive());
+        assertTrue(entity.isDeleted());
+        verify(assetLinkRepository, times(1)).save(entity);
+    }
+
+    @Test
+    void patch_reactivateLink_validatesCardinality() {
+        PatchAssetLinkCommand command = PatchAssetLinkCommand.builder()
+                .assetId("A1")
+                .linkId("L1")
+                .active(true)
+                .requestedBy("tester")
+                .requestTime(Instant.parse("2024-02-01T00:00:00Z"))
+                .build();
+
+        AssetLinkEntity entity = AssetLinkEntity.builder()
+                .id("L1")
+                .assetId("A1")
+                .linkCode("WORKFLOW")
+                .linkSubtype("BULK")
+                .entityType("WORKFLOW")
+                .entityId("WF-1")
+                .active(false)
+                .deleted(false)
+                .build();
+
+        LinkDefinitionEntity definition = LinkDefinitionEntity.builder()
+                .code("WORKFLOW")
+                .entityType("WORKFLOW")
+                .cardinality(LinkCardinality.ONE_TO_ONE)
+                .enabled(true)
+                .build();
+        definition.setSubtypes(Set.of(buildSubtype(definition, "BULK")));
+
+        when(assetLinkRepository.findByIdAndDeletedIsFalse("L1")).thenReturn(Optional.of(entity));
+        when(linkDefinitionRepository.findByCodeIgnoreCase("WORKFLOW")).thenReturn(Optional.of(definition));
+        when(assetLinkRepository.countByAssetIdAndLinkCodeAndLinkSubtypeAndActiveIsTrueAndDeletedIsFalse("A1", "WORKFLOW", "BULK"))
+                .thenReturn(0L);
+        when(assetLinkRepository.countByEntityTypeAndEntityIdAndLinkCodeAndLinkSubtypeAndActiveIsTrueAndDeletedIsFalse("WORKFLOW", "WF-1", "WORKFLOW", "BULK"))
+                .thenReturn(0L);
+
+        service.patchLink(command);
+
+        assertTrue(entity.isActive());
+        assertFalse(entity.isDeleted());
+        verify(assetLinkRepository).save(entity);
+    }
+
+    @Test
+    void patch_updatesValidityDates() {
+        Instant newFrom = Instant.parse("2024-03-01T00:00:00Z");
+        Instant newTo = Instant.parse("2024-03-31T00:00:00Z");
+        PatchAssetLinkCommand command = PatchAssetLinkCommand.builder()
+                .assetId("A1")
+                .linkId("L1")
+                .validFrom(newFrom)
+                .validTo(newTo)
+                .requestedBy("tester")
+                .requestTime(Instant.parse("2024-03-02T00:00:00Z"))
+                .build();
+
+        AssetLinkEntity entity = AssetLinkEntity.builder()
+                .id("L1")
+                .assetId("A1")
+                .active(true)
+                .deleted(false)
+                .build();
+
+        when(assetLinkRepository.findByIdAndDeletedIsFalse("L1")).thenReturn(Optional.of(entity));
+
+        service.patchLink(command);
+
+        assertEquals(newFrom, entity.getValidFrom());
+        assertEquals(newTo, entity.getValidTo());
+        verify(assetLinkRepository).save(entity);
+    }
+
+    private LinkSubtypeDefinitionEntity buildSubtype(LinkDefinitionEntity parent, String subtype) {
+        return LinkSubtypeDefinitionEntity.builder()
+                .id(new LinkSubtypeDefinitionId(parent.getCode(), subtype))
+                .definition(parent)
+                .build();
+    }
+}

--- a/src/test/java/com/db/assetstore/service/AssetQueryServiceImplLinkTest.java
+++ b/src/test/java/com/db/assetstore/service/AssetQueryServiceImplLinkTest.java
@@ -1,0 +1,84 @@
+package com.db.assetstore.service;
+
+import com.db.assetstore.domain.model.link.AssetLink;
+import com.db.assetstore.infra.jpa.AssetEntity;
+import com.db.assetstore.infra.jpa.link.AssetLinkEntity;
+import com.db.assetstore.infra.mapper.AssetLinkMapper;
+import com.db.assetstore.infra.mapper.AssetMapper;
+import com.db.assetstore.infra.repository.AssetRepository;
+import com.db.assetstore.infra.repository.link.AssetLinkRepository;
+import com.db.assetstore.infra.service.AssetQueryServiceImpl;
+import com.db.assetstore.infra.service.search.AssetSearchSpecificationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class AssetQueryServiceImplLinkTest {
+
+    AssetRepository assetRepository;
+    AssetLinkRepository assetLinkRepository;
+    AssetSearchSpecificationService specService;
+    AssetMapper assetMapper;
+    AssetLinkMapper assetLinkMapper;
+
+    AssetQueryServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        assetRepository = mock(AssetRepository.class);
+        assetLinkRepository = mock(AssetLinkRepository.class);
+        specService = mock(AssetSearchSpecificationService.class);
+        assetMapper = mock(AssetMapper.class);
+        assetLinkMapper = spy(new AssetLinkMapper());
+        when(specService.buildSpec(any())).thenReturn((Specification<AssetEntity>) (root, query, cb) -> cb.conjunction());
+        service = new AssetQueryServiceImpl(assetMapper, assetRepository, specService, assetLinkRepository, assetLinkMapper);
+    }
+
+    @Test
+    void findLinksByAsset_returnsMappedLinks() {
+        AssetLinkEntity entity = AssetLinkEntity.builder()
+                .id("L1")
+                .assetId("A1")
+                .linkCode("WORKFLOW")
+                .linkSubtype("BULK")
+                .entityType("WORKFLOW")
+                .entityId("WF-1")
+                .active(true)
+                .deleted(false)
+                .validFrom(Instant.now())
+                .build();
+        when(assetLinkRepository.findByAssetIdAndDeleted("A1", false)).thenReturn(List.of(entity));
+
+        List<AssetLink> links = service.findLinksByAsset("A1", false);
+
+        assertEquals(1, links.size());
+        assertEquals("L1", links.get(0).getId());
+    }
+
+    @Test
+    void findLinksByEntity_returnsMappedLinks() {
+        AssetLinkEntity entity = AssetLinkEntity.builder()
+                .id("L2")
+                .assetId("A1")
+                .linkCode("WORKFLOW")
+                .linkSubtype("BULK")
+                .entityType("WORKFLOW")
+                .entityId("WF-2")
+                .active(true)
+                .deleted(false)
+                .validFrom(Instant.now())
+                .build();
+        when(assetLinkRepository.findByEntityTypeAndEntityIdAndDeleted("WORKFLOW", "WF-2", false)).thenReturn(List.of(entity));
+
+        List<AssetLink> links = service.findLinksByEntity("WORKFLOW", "WF-2", false);
+
+        assertEquals(1, links.size());
+        assertEquals("L2", links.get(0).getId());
+    }
+}

--- a/src/test/java/com/db/assetstore/service/AssetQueryServiceImplTest.java
+++ b/src/test/java/com/db/assetstore/service/AssetQueryServiceImplTest.java
@@ -8,11 +8,13 @@ import com.db.assetstore.domain.model.type.AVString;
 import com.db.assetstore.domain.search.SearchCriteria;
 import com.db.assetstore.infra.jpa.AssetEntity;
 import com.db.assetstore.infra.jpa.AttributeEntity;
+import com.db.assetstore.infra.mapper.AssetLinkMapper;
 import com.db.assetstore.infra.mapper.AssetMapper;
 import com.db.assetstore.infra.mapper.AssetMapperImpl;
 import com.db.assetstore.infra.mapper.AttributesCollectionMapper;
 import com.db.assetstore.infra.repository.AssetRepository;
 import com.db.assetstore.infra.service.AssetQueryServiceImpl;
+import com.db.assetstore.infra.repository.link.AssetLinkRepository;
 import com.db.assetstore.infra.service.search.AssetSearchSpecificationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,6 +36,8 @@ class AssetQueryServiceImplTest {
     AssetMapper assetMapper = new AssetMapperImpl(collectionMapper);
     AssetRepository assetRepo;
     AssetSearchSpecificationService specService;
+    AssetLinkRepository assetLinkRepository;
+    AssetLinkMapper assetLinkMapper = new AssetLinkMapper();
 
     AssetQueryServiceImpl service;
 
@@ -41,7 +45,8 @@ class AssetQueryServiceImplTest {
     void setUp() {
         assetRepo = mock(AssetRepository.class);
         specService = mock(AssetSearchSpecificationService.class);
-        service = new AssetQueryServiceImpl(assetMapper, assetRepo, specService);
+        assetLinkRepository = mock(AssetLinkRepository.class);
+        service = new AssetQueryServiceImpl(assetMapper, assetRepo, specService, assetLinkRepository, assetLinkMapper);
         when(specService.buildSpec(any())).thenReturn(
                 (Specification) (root, query, cb) -> cb.conjunction());
     }


### PR DESCRIPTION
## Summary
- stop exposing link identifiers in the link creation request DTO and corresponding command builder so clients cannot submit their own IDs
- have the asset link command factory and command service always generate a UUID for new links instead of honoring client-provided values
- update the command service unit test expectations to assert that generated identifiers are non-null and returned to callers

## Testing
- `mvn test` *(fails: unable to download the Spring Boot parent POM from Maven Central because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d308cb8f7083308170ab2e425f9827