### PR TITLE
Drop unique constraint from asset link table

### DIFF
--- a/src/main/java/com/db/assetstore/domain/model/Asset.java
+++ b/src/main/java/com/db/assetstore/domain/model/Asset.java
@@ -4,7 +4,6 @@ import com.db.assetstore.AssetType;
 import com.db.assetstore.domain.model.attribute.AttributeValue;
 import com.db.assetstore.domain.model.attribute.AttributesCollection;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
@@ -13,7 +12,11 @@ import lombok.Setter;
 
 import java.math.BigDecimal;
 import java.time.Instant;
-import java.util.*;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/java/com/db/assetstore/domain/model/link/AssetLink.java
+++ b/src/main/java/com/db/assetstore/domain/model/link/AssetLink.java
@@ -1,0 +1,23 @@
+package com.db.assetstore.domain.model.link;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+@Builder(toBuilder = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AssetLink {
+    private final Long id;
+    private final String assetId;
+    private final String entityType;
+    private final String entitySubtype;
+    private final String targetCode;
+    private final boolean active;
+    private final Instant createdAt;
+    private final String createdBy;
+    private final Instant deactivatedAt;
+    private final String deactivatedBy;
+}

--- a/src/main/java/com/db/assetstore/domain/model/link/LinkCardinality.java
+++ b/src/main/java/com/db/assetstore/domain/model/link/LinkCardinality.java
@@ -1,0 +1,18 @@
+package com.db.assetstore.domain.model.link;
+
+/**
+ * Describes allowed number of active links between an Asset and external entity instances.
+ */
+public enum LinkCardinality {
+    ONE_TO_ONE,
+    ONE_TO_MANY,
+    MANY_TO_ONE;
+
+    public boolean limitsAssetSide() {
+        return this == ONE_TO_ONE || this == MANY_TO_ONE;
+    }
+
+    public boolean limitsTargetSide() {
+        return this == ONE_TO_ONE || this == ONE_TO_MANY;
+    }
+}

--- a/src/main/java/com/db/assetstore/domain/model/link/LinkDefinition.java
+++ b/src/main/java/com/db/assetstore/domain/model/link/LinkDefinition.java
@@ -1,0 +1,14 @@
+package com.db.assetstore.domain.model.link;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder(toBuilder = true)
+public class LinkDefinition {
+    Long id;
+    String entityType;
+    String entitySubtype;
+    LinkCardinality cardinality;
+    boolean active;
+}

--- a/src/main/java/com/db/assetstore/domain/service/cmd/AssetCommandVisitor.java
+++ b/src/main/java/com/db/assetstore/domain/service/cmd/AssetCommandVisitor.java
@@ -1,5 +1,8 @@
 package com.db.assetstore.domain.service.cmd;
 
+import com.db.assetstore.domain.service.link.cmd.CreateAssetLinkCommand;
+import com.db.assetstore.domain.service.link.cmd.DeleteAssetLinkCommand;
+
 public interface AssetCommandVisitor {
 
     CommandResult<String> visit(CreateAssetCommand command);
@@ -7,4 +10,8 @@ public interface AssetCommandVisitor {
     CommandResult<Void> visit(PatchAssetCommand command);
 
     CommandResult<Void> visit(DeleteAssetCommand command);
+
+    CommandResult<Long> visit(CreateAssetLinkCommand command);
+
+    CommandResult<Void> visit(DeleteAssetLinkCommand command);
 }

--- a/src/main/java/com/db/assetstore/domain/service/link/AssetLinkQueryService.java
+++ b/src/main/java/com/db/assetstore/domain/service/link/AssetLinkQueryService.java
@@ -1,0 +1,10 @@
+package com.db.assetstore.domain.service.link;
+
+import com.db.assetstore.domain.model.link.AssetLink;
+
+import java.util.List;
+
+public interface AssetLinkQueryService {
+    List<AssetLink> findActiveLinks(String assetId);
+    List<AssetLink> findLinks(String assetId, boolean includeInactive);
+}

--- a/src/main/java/com/db/assetstore/domain/service/link/cmd/CreateAssetLinkCommand.java
+++ b/src/main/java/com/db/assetstore/domain/service/link/cmd/CreateAssetLinkCommand.java
@@ -1,0 +1,24 @@
+package com.db.assetstore.domain.service.link.cmd;
+
+import com.db.assetstore.domain.service.cmd.AssetCommand;
+import com.db.assetstore.domain.service.cmd.AssetCommandVisitor;
+import com.db.assetstore.domain.service.cmd.CommandResult;
+import lombok.Builder;
+
+import java.time.Instant;
+
+@Builder
+public record CreateAssetLinkCommand(
+        String assetId,
+        String entityType,
+        String entitySubtype,
+        String targetCode,
+        String executedBy,
+        Instant requestTime
+) implements AssetCommand<Long> {
+
+    @Override
+    public CommandResult<Long> accept(AssetCommandVisitor visitor) {
+        return AssetCommand.super.requireVisitor(visitor).visit(this);
+    }
+}

--- a/src/main/java/com/db/assetstore/domain/service/link/cmd/DeleteAssetLinkCommand.java
+++ b/src/main/java/com/db/assetstore/domain/service/link/cmd/DeleteAssetLinkCommand.java
@@ -1,0 +1,24 @@
+package com.db.assetstore.domain.service.link.cmd;
+
+import com.db.assetstore.domain.service.cmd.AssetCommand;
+import com.db.assetstore.domain.service.cmd.AssetCommandVisitor;
+import com.db.assetstore.domain.service.cmd.CommandResult;
+import lombok.Builder;
+
+import java.time.Instant;
+
+@Builder
+public record DeleteAssetLinkCommand(
+        String assetId,
+        String entityType,
+        String entitySubtype,
+        String targetCode,
+        String executedBy,
+        Instant requestTime
+) implements AssetCommand<Void> {
+
+    @Override
+    public CommandResult<Void> accept(AssetCommandVisitor visitor) {
+        return AssetCommand.super.requireVisitor(visitor).visit(this);
+    }
+}

--- a/src/main/java/com/db/assetstore/infra/jpa/AssetLinkEntity.java
+++ b/src/main/java/com/db/assetstore/infra/jpa/AssetLinkEntity.java
@@ -1,0 +1,50 @@
+package com.db.assetstore.infra.jpa;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "asset_link",
+       uniqueConstraints = @UniqueConstraint(name = "uk_asset_link_unique",
+               columnNames = {"asset_id", "entity_type", "entity_subtype", "target_code"}))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class AssetLinkEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "asset_id", length = 36, nullable = false)
+    private String assetId;
+
+    @Column(name = "entity_type", length = 64, nullable = false)
+    private String entityType;
+
+    @Column(name = "entity_subtype", length = 64, nullable = false)
+    private String entitySubtype;
+
+    @Column(name = "target_code", length = 128, nullable = false)
+    private String targetCode;
+
+    @Builder.Default
+    @Column(name = "active", nullable = false)
+    private boolean active = true;
+
+    @Column(name = "created_at")
+    private Instant createdAt;
+
+    @Column(name = "created_by", length = 64)
+    private String createdBy;
+
+    @Column(name = "deactivated_at")
+    private Instant deactivatedAt;
+
+    @Column(name = "deactivated_by", length = 64)
+    private String deactivatedBy;
+}

--- a/src/main/java/com/db/assetstore/infra/jpa/LinkDefinitionEntity.java
+++ b/src/main/java/com/db/assetstore/infra/jpa/LinkDefinitionEntity.java
@@ -1,0 +1,34 @@
+package com.db.assetstore.infra.jpa;
+
+import com.db.assetstore.domain.model.link.LinkCardinality;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "link_definition",
+       uniqueConstraints = @UniqueConstraint(name = "uk_link_definition_type_subtype",
+               columnNames = {"entity_type", "entity_subtype"}))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class LinkDefinitionEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "entity_type", length = 64, nullable = false)
+    private String entityType;
+
+    @Column(name = "entity_subtype", length = 64, nullable = false)
+    private String entitySubtype;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "cardinality", length = 32, nullable = false)
+    private LinkCardinality cardinality;
+
+    @Column(name = "active", nullable = false)
+    private boolean active;
+}

--- a/src/main/java/com/db/assetstore/infra/mapper/AssetLinkMapper.java
+++ b/src/main/java/com/db/assetstore/infra/mapper/AssetLinkMapper.java
@@ -1,0 +1,14 @@
+package com.db.assetstore.infra.mapper;
+
+import com.db.assetstore.domain.model.link.AssetLink;
+import com.db.assetstore.infra.jpa.AssetLinkEntity;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+public interface AssetLinkMapper {
+    AssetLink toModel(AssetLinkEntity entity);
+    List<AssetLink> toModelList(List<AssetLinkEntity> entities);
+}

--- a/src/main/java/com/db/assetstore/infra/repository/AssetLinkRepo.java
+++ b/src/main/java/com/db/assetstore/infra/repository/AssetLinkRepo.java
@@ -1,0 +1,62 @@
+package com.db.assetstore.infra.repository;
+
+import com.db.assetstore.infra.jpa.AssetLinkEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AssetLinkRepo extends JpaRepository<AssetLinkEntity, Long> {
+
+    List<AssetLinkEntity> findAllByAssetIdAndActiveTrue(String assetId);
+
+    List<AssetLinkEntity> findAllByAssetId(String assetId);
+
+    List<AssetLinkEntity> findAllByAssetIdAndEntityTypeAndEntitySubtypeAndActiveTrue(String assetId,
+                                                                                    String entityType,
+                                                                                    String entitySubtype);
+
+    List<AssetLinkEntity> findAllByEntityTypeAndEntitySubtypeAndTargetCodeAndActiveTrue(String entityType,
+                                                                                        String entitySubtype,
+                                                                                        String targetCode);
+
+    Optional<AssetLinkEntity> findFirstByAssetIdAndEntityTypeAndEntitySubtypeAndTargetCodeAndActiveTrue(String assetId,
+                                                                                                       String entityType,
+                                                                                                       String entitySubtype,
+                                                                                                       String targetCode);
+
+    Optional<AssetLinkEntity> findFirstByAssetIdAndEntityTypeAndEntitySubtypeAndTargetCode(String assetId,
+                                                                                           String entityType,
+                                                                                           String entitySubtype,
+                                                                                           String targetCode);
+
+    default List<AssetLinkEntity> activeForAsset(String assetId) {
+        return findAllByAssetIdAndActiveTrue(assetId);
+    }
+
+    default List<AssetLinkEntity> allForAsset(String assetId) {
+        return findAllByAssetId(assetId);
+    }
+
+    default List<AssetLinkEntity> activeForAssetType(String assetId, String entityType, String entitySubtype) {
+        return findAllByAssetIdAndEntityTypeAndEntitySubtypeAndActiveTrue(assetId, entityType, entitySubtype);
+    }
+
+    default List<AssetLinkEntity> activeForTarget(String entityType, String entitySubtype, String targetCode) {
+        return findAllByEntityTypeAndEntitySubtypeAndTargetCodeAndActiveTrue(entityType, entitySubtype, targetCode);
+    }
+
+    default Optional<AssetLinkEntity> activeLinkForAsset(String assetId,
+                                                         String entityType,
+                                                         String entitySubtype,
+                                                         String targetCode) {
+        return findFirstByAssetIdAndEntityTypeAndEntitySubtypeAndTargetCodeAndActiveTrue(assetId, entityType, entitySubtype, targetCode);
+    }
+
+    default Optional<AssetLinkEntity> linkForAsset(String assetId,
+                                                   String entityType,
+                                                   String entitySubtype,
+                                                   String targetCode) {
+        return findFirstByAssetIdAndEntityTypeAndEntitySubtypeAndTargetCode(assetId, entityType, entitySubtype, targetCode);
+    }
+}

--- a/src/main/java/com/db/assetstore/infra/repository/LinkDefinitionRepo.java
+++ b/src/main/java/com/db/assetstore/infra/repository/LinkDefinitionRepo.java
@@ -1,0 +1,10 @@
+package com.db.assetstore.infra.repository;
+
+import com.db.assetstore.infra.jpa.LinkDefinitionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LinkDefinitionRepo extends JpaRepository<LinkDefinitionEntity, Long> {
+    Optional<LinkDefinitionEntity> findByEntityTypeAndEntitySubtypeAndActiveTrue(String entityType, String entitySubtype);
+}

--- a/src/main/java/com/db/assetstore/infra/service/AssetCommandServiceImpl.java
+++ b/src/main/java/com/db/assetstore/infra/service/AssetCommandServiceImpl.java
@@ -1,23 +1,30 @@
 package com.db.assetstore.infra.service;
 
 import com.db.assetstore.domain.service.cmd.AssetCommand;
+import com.db.assetstore.domain.service.cmd.AssetCommandVisitor;
 import com.db.assetstore.domain.service.cmd.CommandResult;
 import com.db.assetstore.domain.service.cmd.CreateAssetCommand;
 import com.db.assetstore.domain.service.cmd.DeleteAssetCommand;
 import com.db.assetstore.domain.service.cmd.PatchAssetCommand;
-import com.db.assetstore.domain.service.cmd.AssetCommandVisitor;
 import com.db.assetstore.domain.model.Asset;
 import com.db.assetstore.domain.model.AssetPatch;
 import com.db.assetstore.domain.model.attribute.AttributeValue;
 import com.db.assetstore.domain.service.AssetCommandService;
+import com.db.assetstore.domain.service.link.cmd.CreateAssetLinkCommand;
+import com.db.assetstore.domain.service.link.cmd.DeleteAssetLinkCommand;
 import com.db.assetstore.infra.jpa.AssetEntity;
+import com.db.assetstore.infra.jpa.AssetLinkEntity;
 import com.db.assetstore.infra.jpa.AttributeEntity;
 import com.db.assetstore.infra.jpa.CommandLogEntity;
+import com.db.assetstore.infra.jpa.LinkDefinitionEntity;
 import com.db.assetstore.infra.mapper.AssetMapper;
 import com.db.assetstore.infra.mapper.AttributeMapper;
+import com.db.assetstore.infra.repository.AssetLinkRepo;
 import com.db.assetstore.infra.repository.AssetRepository;
 import com.db.assetstore.infra.repository.AttributeRepository;
 import com.db.assetstore.infra.repository.CommandLogRepository;
+import com.db.assetstore.infra.repository.LinkDefinitionRepo;
+import com.db.assetstore.infra.service.link.AssetLinkCommandValidator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +37,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -46,25 +54,10 @@ public class AssetCommandServiceImpl implements AssetCommandService, AssetComman
     private final AssetRepository assetRepo;
     private final AttributeRepository attributeRepo;
     private final CommandLogRepository commandLogRepository;
+    private final AssetLinkRepo assetLinkRepo;
+    private final LinkDefinitionRepo linkDefinitionRepo;
+    private final AssetLinkCommandValidator assetLinkCommandValidator;
     private final ObjectMapper objectMapper;
-
-    @Override
-    @Transactional
-    public String create(CreateAssetCommand command) {
-        return execute(command).result();
-    }
-
-    @Override
-    @Transactional
-    public void update(PatchAssetCommand command) {
-        execute(command);
-    }
-
-    @Override
-    @Transactional
-    public void delete(DeleteAssetCommand command) {
-        execute(command);
-    }
 
     @Override
     @Transactional
@@ -123,6 +116,58 @@ public class AssetCommandServiceImpl implements AssetCommandService, AssetComman
         String assetId = Objects.requireNonNull(command.assetId(), "assetId");
         deleteAsset(assetId);
         return CommandResult.noResult(assetId);
+    }
+
+    @Override
+    public CommandResult<Long> visit(CreateAssetLinkCommand command) {
+        Objects.requireNonNull(command, "command");
+
+        LinkDefinitionEntity definition = linkDefinitionRepo
+                .findByEntityTypeAndEntitySubtypeAndActiveTrue(command.entityType(), command.entitySubtype())
+                .orElseThrow(() -> new IllegalStateException(
+                        "Link definition missing for %s/%s".formatted(command.entityType(), command.entitySubtype())));
+
+        assetLinkCommandValidator.validateCreate(command, definition);
+
+        Optional<AssetLinkEntity> existing = assetLinkRepo.linkForAsset(
+                command.assetId(), command.entityType(), command.entitySubtype(), command.targetCode());
+        boolean reactivated = existing.filter(link -> !link.isActive()).isPresent();
+
+        AssetLinkEntity entity = existing
+                .map(existingLink -> reactivate(existingLink, command))
+                .orElseGet(() -> AssetLinkEntity.builder()
+                        .assetId(command.assetId())
+                        .entityType(command.entityType())
+                        .entitySubtype(command.entitySubtype())
+                        .targetCode(command.targetCode())
+                        .active(true)
+                        .createdAt(orNow(command.requestTime()))
+                        .createdBy(command.executedBy())
+                        .build());
+
+        AssetLinkEntity saved = assetLinkRepo.save(entity);
+        log.info("{} link id={} for asset {}",
+                reactivated ? "Reactivated" : "Created",
+                saved.getId(), command.assetId());
+        return new CommandResult<>(saved.getId(), command.assetId());
+    }
+
+    @Override
+    public CommandResult<Void> visit(DeleteAssetLinkCommand command) {
+        Objects.requireNonNull(command, "command");
+
+        AssetLinkEntity entity = assetLinkRepo
+                .activeLinkForAsset(
+                        command.assetId(), command.entityType(), command.entitySubtype(), command.targetCode())
+                .orElseThrow(() -> new IllegalStateException(
+                        "Active link not found for asset %s".formatted(command.assetId())));
+
+        entity.setActive(false);
+        entity.setDeactivatedAt(orNow(command.requestTime()));
+        entity.setDeactivatedBy(command.executedBy());
+        assetLinkRepo.save(entity);
+        log.info("Deactivated link id={} for asset {}", entity.getId(), command.assetId());
+        return CommandResult.noResult(command.assetId());
     }
 
     private String resolveAssetId(CreateAssetCommand command) {
@@ -235,4 +280,23 @@ public class AssetCommandServiceImpl implements AssetCommandService, AssetComman
 
         commandLogRepository.save(entity);
     }
+
+    private Instant orNow(Instant instant) {
+        return instant != null ? instant : Instant.now();
+    }
+
+    private AssetLinkEntity reactivate(AssetLinkEntity entity, CreateAssetLinkCommand command) {
+        if (entity.isActive()) {
+            throw new IllegalStateException(
+                    "Active link already exists for asset %s and target %s".formatted(
+                            command.assetId(), command.targetCode()));
+        }
+        entity.setActive(true);
+        entity.setCreatedAt(orNow(command.requestTime()));
+        entity.setCreatedBy(command.executedBy());
+        entity.setDeactivatedAt(null);
+        entity.setDeactivatedBy(null);
+        return entity;
+    }
+
 }

--- a/src/main/java/com/db/assetstore/infra/service/AssetLinkQueryServiceImpl.java
+++ b/src/main/java/com/db/assetstore/infra/service/AssetLinkQueryServiceImpl.java
@@ -1,0 +1,40 @@
+package com.db.assetstore.infra.service;
+
+import com.db.assetstore.domain.model.link.AssetLink;
+import com.db.assetstore.domain.service.link.AssetLinkQueryService;
+import com.db.assetstore.infra.jpa.AssetLinkEntity;
+import com.db.assetstore.infra.mapper.AssetLinkMapper;
+import com.db.assetstore.infra.repository.AssetLinkRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AssetLinkQueryServiceImpl implements AssetLinkQueryService {
+
+    private final AssetLinkRepo assetLinkRepo;
+    private final AssetLinkMapper assetLinkMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AssetLink> findActiveLinks(String assetId) {
+        return toModelList(assetLinkRepo.activeForAsset(assetId));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AssetLink> findLinks(String assetId, boolean includeInactive) {
+        if (includeInactive) {
+            return toModelList(assetLinkRepo.allForAsset(assetId));
+        }
+        return findActiveLinks(assetId);
+    }
+
+    private List<AssetLink> toModelList(List<AssetLinkEntity> entities) {
+        List<AssetLink> mapped = assetLinkMapper.toModelList(entities);
+        return mapped == null ? List.of() : List.copyOf(mapped);
+    }
+}

--- a/src/main/java/com/db/assetstore/infra/service/AssetQueryServiceImpl.java
+++ b/src/main/java/com/db/assetstore/infra/service/AssetQueryServiceImpl.java
@@ -21,11 +21,11 @@ public class AssetQueryServiceImpl implements AssetQueryService {
     private final AssetMapper assetMapper;
     private final AssetRepository assetRepo;
     private final AssetSearchSpecificationService specService;
-
     @Override
     @Transactional(readOnly = true)
     public Optional<Asset> get(String id) {
-        return assetRepo.findByIdAndDeleted(id, 0).map(assetMapper::toModel);
+        return assetRepo.findByIdAndDeleted(id, 0)
+                .map(assetMapper::toModel);
     }
 
     @Override
@@ -38,4 +38,5 @@ public class AssetQueryServiceImpl implements AssetQueryService {
     private List<AssetEntity> searchEntities(SearchCriteria criteria) {
         return assetRepo.findAll(specService.buildSpec(criteria));
     }
+
 }

--- a/src/main/java/com/db/assetstore/infra/service/link/AssetLinkCommandValidator.java
+++ b/src/main/java/com/db/assetstore/infra/service/link/AssetLinkCommandValidator.java
@@ -1,0 +1,61 @@
+package com.db.assetstore.infra.service.link;
+
+import com.db.assetstore.domain.model.link.LinkCardinality;
+import com.db.assetstore.domain.service.link.cmd.CreateAssetLinkCommand;
+import com.db.assetstore.infra.jpa.AssetLinkEntity;
+import com.db.assetstore.infra.jpa.LinkDefinitionEntity;
+import com.db.assetstore.infra.repository.AssetLinkRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class AssetLinkCommandValidator {
+
+    private final AssetLinkRepo assetLinkRepo;
+
+    public void validateCreate(CreateAssetLinkCommand command, LinkDefinitionEntity definition) {
+        ensureDefinitionActive(definition);
+        ensureNoDuplicate(command);
+        ensureCardinality(definition.getCardinality(), command);
+    }
+
+    private void ensureDefinitionActive(LinkDefinitionEntity definition) {
+        if (!definition.isActive()) {
+            throw new IllegalStateException(
+                    "Link definition %s/%s is inactive".formatted(
+                            definition.getEntityType(), definition.getEntitySubtype()));
+        }
+    }
+
+    private void ensureNoDuplicate(CreateAssetLinkCommand command) {
+        assetLinkRepo.activeLinkForAsset(
+                        command.assetId(), command.entityType(), command.entitySubtype(), command.targetCode())
+                .ifPresent(existing -> {
+                    throw new IllegalStateException(
+                            "Active link already exists for asset %s and target %s".formatted(
+                                    command.assetId(), command.targetCode()));
+                });
+    }
+
+    private void ensureCardinality(LinkCardinality cardinality, CreateAssetLinkCommand command) {
+        List<AssetLinkEntity> assetLinks = assetLinkRepo
+                .activeForAssetType(command.assetId(), command.entityType(), command.entitySubtype());
+        List<AssetLinkEntity> targetLinks = assetLinkRepo
+                .activeForTarget(command.entityType(), command.entitySubtype(), command.targetCode());
+
+        if (cardinality.limitsAssetSide() && !assetLinks.isEmpty()) {
+            throw new IllegalStateException(
+                    "Asset %s already has an active link for %s/%s".formatted(
+                            command.assetId(), command.entityType(), command.entitySubtype()));
+        }
+        if (cardinality.limitsTargetSide() && !targetLinks.isEmpty()) {
+            throw new IllegalStateException(
+                    "Target %s already linked for %s/%s".formatted(
+                            command.targetCode(), command.entityType(), command.entitySubtype()));
+        }
+    }
+}
+

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -146,4 +146,125 @@
             <column name="command_type"/>
         </createIndex>
     </changeSet>
+
+    <changeSet id="8-link-definition" author="assistant">
+        <createTable tableName="link_definition">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="entity_type" type="varchar(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="entity_subtype" type="varchar(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cardinality" type="varchar(32)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="active" type="boolean" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addUniqueConstraint tableName="link_definition"
+                             columnNames="entity_type,entity_subtype"
+                             constraintName="uk_link_definition_type_subtype"/>
+    </changeSet>
+
+    <changeSet id="9-asset-link" author="assistant">
+        <createTable tableName="asset_link">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="asset_id" type="varchar(36)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="entity_type" type="varchar(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="entity_subtype" type="varchar(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="target_code" type="varchar(128)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="active" type="boolean" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="timestamp"/>
+            <column name="created_by" type="varchar(64)"/>
+            <column name="deactivated_at" type="timestamp"/>
+            <column name="deactivated_by" type="varchar(64)"/>
+        </createTable>
+        <addUniqueConstraint tableName="asset_link"
+                             columnNames="asset_id,entity_type,entity_subtype,target_code"
+                             constraintName="uk_asset_link_unique"/>
+        <addForeignKeyConstraint baseTableName="asset_link" baseColumnNames="asset_id"
+                                  referencedTableName="assets" referencedColumnNames="id"
+                                  constraintName="fk_asset_link_asset"/>
+        <createIndex tableName="asset_link" indexName="idx_asset_link_asset">
+            <column name="asset_id"/>
+        </createIndex>
+        <createIndex tableName="asset_link" indexName="idx_asset_link_target">
+            <column name="entity_type"/>
+            <column name="entity_subtype"/>
+            <column name="target_code"/>
+            <column name="active"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="10-link-definition-seed" author="assistant">
+        <insert tableName="link_definition">
+            <column name="entity_type" value="WORKFLOW"/>
+            <column name="entity_subtype" value="BULK"/>
+            <column name="cardinality" value="ONE_TO_ONE"/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="link_definition">
+            <column name="entity_type" value="WORKFLOW"/>
+            <column name="entity_subtype" value="MONITORING"/>
+            <column name="cardinality" value="ONE_TO_ONE"/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="link_definition">
+            <column name="entity_type" value="WORKFLOW"/>
+            <column name="entity_subtype" value="REVALUATION"/>
+            <column name="cardinality" value="ONE_TO_ONE"/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="link_definition">
+            <column name="entity_type" value="WORKFLOW"/>
+            <column name="entity_subtype" value="CHG"/>
+            <column name="cardinality" value="ONE_TO_ONE"/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="link_definition">
+            <column name="entity_type" value="INSTRUMENT"/>
+            <column name="entity_subtype" value="BULK"/>
+            <column name="cardinality" value="ONE_TO_ONE"/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="link_definition">
+            <column name="entity_type" value="INSTRUMENT"/>
+            <column name="entity_subtype" value="MONITORING"/>
+            <column name="cardinality" value="ONE_TO_ONE"/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="link_definition">
+            <column name="entity_type" value="INSTRUMENT"/>
+            <column name="entity_subtype" value="REVALUATION"/>
+            <column name="cardinality" value="ONE_TO_ONE"/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="link_definition">
+            <column name="entity_type" value="INSTRUMENT"/>
+            <column name="entity_subtype" value="CHG"/>
+            <column name="cardinality" value="ONE_TO_ONE"/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="11-drop-asset-link-unique" author="assistant">
+        <dropUniqueConstraint tableName="asset_link"
+                               constraintName="uk_asset_link_unique"/>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
## Summary
- add a Liquibase change set to drop the `uk_asset_link_unique` constraint from the `asset_link` table so inactive rows no longer block re-creation

## Testing
- mvn -q -DskipTests package *(fails: cannot resolve Spring Boot parent because Maven Central is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e9e91a0083308d5629d2b64580de