### PR TITLE
Introduce AssetLinkException for link domain errors

### DIFF
--- a/src/main/java/com/db/assetstore/domain/model/Asset.java
+++ b/src/main/java/com/db/assetstore/domain/model/Asset.java
@@ -4,7 +4,6 @@ import com.db.assetstore.AssetType;
 import com.db.assetstore.domain.model.attribute.AttributeValue;
 import com.db.assetstore.domain.model.attribute.AttributesCollection;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
@@ -13,7 +12,11 @@ import lombok.Setter;
 
 import java.math.BigDecimal;
 import java.time.Instant;
-import java.util.*;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/java/com/db/assetstore/domain/model/link/AssetLink.java
+++ b/src/main/java/com/db/assetstore/domain/model/link/AssetLink.java
@@ -1,0 +1,25 @@
+package com.db.assetstore.domain.model.link;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Value;
+
+import java.time.Instant;
+import java.util.Optional;
+
+@Value
+@Builder(toBuilder = true)
+@JsonInclude(JsonInclude.Include.NON_ABSENT)
+public class AssetLink {
+    private final Long id;
+    private final String assetId;
+    private final String entityType;
+    private final String entitySubtype;
+    private final String targetCode;
+    private final boolean active;
+    private final Instant createdAt;
+    private final String createdBy;
+    @Builder.Default
+    private final Optional<Instant> deactivatedAt = Optional.empty();
+    private final String deactivatedBy;
+}

--- a/src/main/java/com/db/assetstore/domain/model/link/LinkCardinality.java
+++ b/src/main/java/com/db/assetstore/domain/model/link/LinkCardinality.java
@@ -1,0 +1,18 @@
+package com.db.assetstore.domain.model.link;
+
+/**
+ * Describes allowed number of active links between an Asset and external entity instances.
+ */
+public enum LinkCardinality {
+    ASSET_ONE_TARGET_ONE,
+    ASSET_MANY_TARGET_ONE,
+    ASSET_ONE_TARGET_MANY;
+
+    public boolean limitsAssetSide() {
+        return this == ASSET_ONE_TARGET_ONE || this == ASSET_ONE_TARGET_MANY;
+    }
+
+    public boolean limitsTargetSide() {
+        return this == ASSET_ONE_TARGET_ONE || this == ASSET_MANY_TARGET_ONE;
+    }
+}

--- a/src/main/java/com/db/assetstore/domain/model/link/LinkDefinition.java
+++ b/src/main/java/com/db/assetstore/domain/model/link/LinkDefinition.java
@@ -1,0 +1,14 @@
+package com.db.assetstore.domain.model.link;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder(toBuilder = true)
+public class LinkDefinition {
+    Long id;
+    String entityType;
+    String entitySubtype;
+    LinkCardinality cardinality;
+    boolean active;
+}

--- a/src/main/java/com/db/assetstore/domain/service/cmd/AssetCommandVisitor.java
+++ b/src/main/java/com/db/assetstore/domain/service/cmd/AssetCommandVisitor.java
@@ -1,5 +1,8 @@
 package com.db.assetstore.domain.service.cmd;
 
+import com.db.assetstore.domain.service.link.cmd.CreateAssetLinkCommand;
+import com.db.assetstore.domain.service.link.cmd.DeleteAssetLinkCommand;
+
 public interface AssetCommandVisitor {
 
     CommandResult<String> visit(CreateAssetCommand command);
@@ -7,4 +10,8 @@ public interface AssetCommandVisitor {
     CommandResult<Void> visit(PatchAssetCommand command);
 
     CommandResult<Void> visit(DeleteAssetCommand command);
+
+    CommandResult<Long> visit(CreateAssetLinkCommand command);
+
+    CommandResult<Void> visit(DeleteAssetLinkCommand command);
 }

--- a/src/main/java/com/db/assetstore/domain/service/link/AssetLinkException.java
+++ b/src/main/java/com/db/assetstore/domain/service/link/AssetLinkException.java
@@ -1,0 +1,15 @@
+package com.db.assetstore.domain.service.link;
+
+/**
+ * Exception thrown when asset link domain validation fails.
+ */
+public class AssetLinkException extends RuntimeException {
+
+    public AssetLinkException(String message) {
+        super(message);
+    }
+
+    public AssetLinkException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/db/assetstore/domain/service/link/AssetLinkQueryService.java
+++ b/src/main/java/com/db/assetstore/domain/service/link/AssetLinkQueryService.java
@@ -1,0 +1,10 @@
+package com.db.assetstore.domain.service.link;
+
+import com.db.assetstore.domain.model.link.AssetLink;
+
+import java.util.List;
+
+public interface AssetLinkQueryService {
+    List<AssetLink> findActiveLinks(String assetId);
+    List<AssetLink> findLinks(String assetId, boolean includeInactive);
+}

--- a/src/main/java/com/db/assetstore/domain/service/link/cmd/CreateAssetLinkCommand.java
+++ b/src/main/java/com/db/assetstore/domain/service/link/cmd/CreateAssetLinkCommand.java
@@ -1,0 +1,24 @@
+package com.db.assetstore.domain.service.link.cmd;
+
+import com.db.assetstore.domain.service.cmd.AssetCommand;
+import com.db.assetstore.domain.service.cmd.AssetCommandVisitor;
+import com.db.assetstore.domain.service.cmd.CommandResult;
+import lombok.Builder;
+
+import java.time.Instant;
+
+@Builder
+public record CreateAssetLinkCommand(
+        String assetId,
+        String entityType,
+        String entitySubtype,
+        String targetCode,
+        String executedBy,
+        Instant requestTime
+) implements AssetCommand<Long> {
+
+    @Override
+    public CommandResult<Long> accept(AssetCommandVisitor visitor) {
+        return AssetCommand.super.requireVisitor(visitor).visit(this);
+    }
+}

--- a/src/main/java/com/db/assetstore/domain/service/link/cmd/DeleteAssetLinkCommand.java
+++ b/src/main/java/com/db/assetstore/domain/service/link/cmd/DeleteAssetLinkCommand.java
@@ -1,0 +1,24 @@
+package com.db.assetstore.domain.service.link.cmd;
+
+import com.db.assetstore.domain.service.cmd.AssetCommand;
+import com.db.assetstore.domain.service.cmd.AssetCommandVisitor;
+import com.db.assetstore.domain.service.cmd.CommandResult;
+import lombok.Builder;
+
+import java.time.Instant;
+
+@Builder
+public record DeleteAssetLinkCommand(
+        String assetId,
+        String entityType,
+        String entitySubtype,
+        String targetCode,
+        String executedBy,
+        Instant requestTime
+) implements AssetCommand<Void> {
+
+    @Override
+    public CommandResult<Void> accept(AssetCommandVisitor visitor) {
+        return AssetCommand.super.requireVisitor(visitor).visit(this);
+    }
+}

--- a/src/main/java/com/db/assetstore/infra/jpa/AssetLinkEntity.java
+++ b/src/main/java/com/db/assetstore/infra/jpa/AssetLinkEntity.java
@@ -1,0 +1,48 @@
+package com.db.assetstore.infra.jpa;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "asset_link")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class AssetLinkEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "asset_id", length = 36, nullable = false)
+    private String assetId;
+
+    @Column(name = "entity_type", length = 64, nullable = false)
+    private String entityType;
+
+    @Column(name = "entity_subtype", length = 64, nullable = false)
+    private String entitySubtype;
+
+    @Column(name = "target_code", length = 128, nullable = false)
+    private String targetCode;
+
+    @Builder.Default
+    @Column(name = "active", nullable = false)
+    private boolean active = true;
+
+    @Column(name = "created_at")
+    private Instant createdAt;
+
+    @Column(name = "created_by", length = 64)
+    private String createdBy;
+
+    @Column(name = "deactivated_at")
+    private Instant deactivatedAt;
+
+    @Column(name = "deactivated_by", length = 64)
+    private String deactivatedBy;
+}

--- a/src/main/java/com/db/assetstore/infra/jpa/LinkDefinitionEntity.java
+++ b/src/main/java/com/db/assetstore/infra/jpa/LinkDefinitionEntity.java
@@ -1,0 +1,34 @@
+package com.db.assetstore.infra.jpa;
+
+import com.db.assetstore.domain.model.link.LinkCardinality;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "link_definition",
+       uniqueConstraints = @UniqueConstraint(name = "uk_link_definition_type_subtype",
+               columnNames = {"entity_type", "entity_subtype"}))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class LinkDefinitionEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "entity_type", length = 64, nullable = false)
+    private String entityType;
+
+    @Column(name = "entity_subtype", length = 64, nullable = false)
+    private String entitySubtype;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "cardinality", length = 32, nullable = false)
+    private LinkCardinality cardinality;
+
+    @Column(name = "active", nullable = false)
+    private boolean active;
+}

--- a/src/main/java/com/db/assetstore/infra/mapper/AssetLinkMapper.java
+++ b/src/main/java/com/db/assetstore/infra/mapper/AssetLinkMapper.java
@@ -1,0 +1,16 @@
+package com.db.assetstore.infra.mapper;
+
+import com.db.assetstore.domain.model.link.AssetLink;
+import com.db.assetstore.infra.jpa.AssetLinkEntity;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+public interface AssetLinkMapper {
+    @Mapping(target = "deactivatedAt", expression = "java(java.util.Optional.ofNullable(entity.getDeactivatedAt()))")
+    AssetLink toModel(AssetLinkEntity entity);
+    List<AssetLink> toModelList(List<AssetLinkEntity> entities);
+}

--- a/src/main/java/com/db/assetstore/infra/repository/AssetLinkRepo.java
+++ b/src/main/java/com/db/assetstore/infra/repository/AssetLinkRepo.java
@@ -1,0 +1,67 @@
+package com.db.assetstore.infra.repository;
+
+import com.db.assetstore.infra.jpa.AssetLinkEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AssetLinkRepo extends JpaRepository<AssetLinkEntity, Long>, JpaSpecificationExecutor<AssetLinkEntity> {
+
+    @Query("""
+        select l from AssetLinkEntity l
+        where l.assetId = :assetId and l.active = true
+        order by l.id desc
+        """)
+    List<AssetLinkEntity> activeForAsset(String assetId);
+
+    @Query("""
+        select l from AssetLinkEntity l
+        where l.assetId = :assetId
+        order by l.id desc
+        """)
+    List<AssetLinkEntity> allForAsset(String assetId);
+
+    default List<AssetLinkEntity> activeForAssetType(String assetId, String entityType, String entitySubtype) {
+        return findAll(AssetLinkSpecifications.builder()
+                .assetId(assetId)
+                .entityType(entityType, entitySubtype)
+                .active(true)
+                .build());
+    }
+
+    @Query("""
+        select l from AssetLinkEntity l
+        where l.entityType = :entityType
+          and l.entitySubtype = :entitySubtype
+          and l.targetCode = :targetCode
+          and l.active = true
+        order by l.id desc
+        """)
+    List<AssetLinkEntity> activeForTarget(String entityType, String entitySubtype, String targetCode);
+
+    default Optional<AssetLinkEntity> activeLink(String assetId,
+                                                 String entityType,
+                                                 String entitySubtype,
+                                                 String targetCode) {
+        return findOne(AssetLinkSpecifications.builder()
+                .assetId(assetId)
+                .entityType(entityType, entitySubtype)
+                .targetCode(targetCode)
+                .active(true)
+                .build());
+    }
+
+    default Optional<AssetLinkEntity> link(String assetId,
+                                           String entityType,
+                                           String entitySubtype,
+                                           String targetCode) {
+        return findOne(AssetLinkSpecifications.builder()
+                .assetId(assetId)
+                .entityType(entityType, entitySubtype)
+                .targetCode(targetCode)
+                .build());
+    }
+}

--- a/src/main/java/com/db/assetstore/infra/repository/AssetLinkSpecifications.java
+++ b/src/main/java/com/db/assetstore/infra/repository/AssetLinkSpecifications.java
@@ -1,0 +1,53 @@
+package com.db.assetstore.infra.repository;
+
+import com.db.assetstore.infra.jpa.AssetLinkEntity;
+import org.springframework.data.jpa.domain.Specification;
+
+public final class AssetLinkSpecifications {
+
+    private AssetLinkSpecifications() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private Specification<AssetLinkEntity> spec = Specification.where(null);
+
+        public Builder assetId(String assetId) {
+            if (assetId != null) {
+                spec = spec.and((root, query, cb) -> cb.equal(root.get("assetId"), assetId));
+            }
+            return this;
+        }
+
+        public Builder entityType(String entityType, String entitySubtype) {
+            if (entityType != null) {
+                spec = spec.and((root, query, cb) -> cb.equal(root.get("entityType"), entityType));
+            }
+            if (entitySubtype != null) {
+                spec = spec.and((root, query, cb) -> cb.equal(root.get("entitySubtype"), entitySubtype));
+            }
+            return this;
+        }
+
+        public Builder targetCode(String targetCode) {
+            if (targetCode != null) {
+                spec = spec.and((root, query, cb) -> cb.equal(root.get("targetCode"), targetCode));
+            }
+            return this;
+        }
+
+        public Builder active(Boolean active) {
+            if (active != null) {
+                spec = spec.and((root, query, cb) -> cb.equal(root.get("active"), active));
+            }
+            return this;
+        }
+
+        public Specification<AssetLinkEntity> build() {
+            return spec;
+        }
+    }
+}

--- a/src/main/java/com/db/assetstore/infra/repository/LinkDefinitionRepo.java
+++ b/src/main/java/com/db/assetstore/infra/repository/LinkDefinitionRepo.java
@@ -1,0 +1,10 @@
+package com.db.assetstore.infra.repository;
+
+import com.db.assetstore.infra.jpa.LinkDefinitionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LinkDefinitionRepo extends JpaRepository<LinkDefinitionEntity, Long> {
+    Optional<LinkDefinitionEntity> findByEntityTypeAndEntitySubtypeAndActiveTrue(String entityType, String entitySubtype);
+}

--- a/src/main/java/com/db/assetstore/infra/service/AssetCommandServiceImpl.java
+++ b/src/main/java/com/db/assetstore/infra/service/AssetCommandServiceImpl.java
@@ -1,23 +1,31 @@
 package com.db.assetstore.infra.service;
 
 import com.db.assetstore.domain.service.cmd.AssetCommand;
+import com.db.assetstore.domain.service.cmd.AssetCommandVisitor;
 import com.db.assetstore.domain.service.cmd.CommandResult;
 import com.db.assetstore.domain.service.cmd.CreateAssetCommand;
 import com.db.assetstore.domain.service.cmd.DeleteAssetCommand;
 import com.db.assetstore.domain.service.cmd.PatchAssetCommand;
-import com.db.assetstore.domain.service.cmd.AssetCommandVisitor;
 import com.db.assetstore.domain.model.Asset;
 import com.db.assetstore.domain.model.AssetPatch;
 import com.db.assetstore.domain.model.attribute.AttributeValue;
 import com.db.assetstore.domain.service.AssetCommandService;
+import com.db.assetstore.domain.service.link.AssetLinkException;
+import com.db.assetstore.domain.service.link.cmd.CreateAssetLinkCommand;
+import com.db.assetstore.domain.service.link.cmd.DeleteAssetLinkCommand;
 import com.db.assetstore.infra.jpa.AssetEntity;
+import com.db.assetstore.infra.jpa.AssetLinkEntity;
 import com.db.assetstore.infra.jpa.AttributeEntity;
 import com.db.assetstore.infra.jpa.CommandLogEntity;
+import com.db.assetstore.infra.jpa.LinkDefinitionEntity;
 import com.db.assetstore.infra.mapper.AssetMapper;
 import com.db.assetstore.infra.mapper.AttributeMapper;
+import com.db.assetstore.infra.repository.AssetLinkRepo;
 import com.db.assetstore.infra.repository.AssetRepository;
 import com.db.assetstore.infra.repository.AttributeRepository;
 import com.db.assetstore.infra.repository.CommandLogRepository;
+import com.db.assetstore.infra.repository.LinkDefinitionRepo;
+import com.db.assetstore.infra.service.link.AssetLinkCommandValidator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +38,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -46,25 +55,10 @@ public class AssetCommandServiceImpl implements AssetCommandService, AssetComman
     private final AssetRepository assetRepo;
     private final AttributeRepository attributeRepo;
     private final CommandLogRepository commandLogRepository;
+    private final AssetLinkRepo assetLinkRepo;
+    private final LinkDefinitionRepo linkDefinitionRepo;
+    private final AssetLinkCommandValidator assetLinkCommandValidator;
     private final ObjectMapper objectMapper;
-
-    @Override
-    @Transactional
-    public String create(CreateAssetCommand command) {
-        return execute(command).result();
-    }
-
-    @Override
-    @Transactional
-    public void update(PatchAssetCommand command) {
-        execute(command);
-    }
-
-    @Override
-    @Transactional
-    public void delete(DeleteAssetCommand command) {
-        execute(command);
-    }
 
     @Override
     @Transactional
@@ -123,6 +117,30 @@ public class AssetCommandServiceImpl implements AssetCommandService, AssetComman
         String assetId = Objects.requireNonNull(command.assetId(), "assetId");
         deleteAsset(assetId);
         return CommandResult.noResult(assetId);
+    }
+
+    @Override
+    public CommandResult<Long> visit(CreateAssetLinkCommand command) {
+        Objects.requireNonNull(command, "command");
+
+        LinkDefinitionEntity definition = findActiveDefinition(command);
+        assetLinkCommandValidator.validateCreate(command, definition);
+
+        LinkPersistenceResult result = persistLink(command);
+        log.info("{} link id={} for asset {}",
+                result.reactivated() ? "Reactivated" : "Created",
+                result.entity().getId(), command.assetId());
+        return new CommandResult<>(result.entity().getId(), command.assetId());
+    }
+
+    @Override
+    public CommandResult<Void> visit(DeleteAssetLinkCommand command) {
+        Objects.requireNonNull(command, "command");
+
+        AssetLinkEntity entity = requireActiveLink(command);
+        deactivateLink(command, entity);
+        log.info("Deactivated link id={} for asset {}", entity.getId(), command.assetId());
+        return CommandResult.noResult(command.assetId());
     }
 
     private String resolveAssetId(CreateAssetCommand command) {
@@ -235,4 +253,73 @@ public class AssetCommandServiceImpl implements AssetCommandService, AssetComman
 
         commandLogRepository.save(entity);
     }
+
+    private Instant orNow(Instant instant) {
+        return instant != null ? instant : Instant.now();
+    }
+
+    private LinkDefinitionEntity findActiveDefinition(CreateAssetLinkCommand command) {
+        return linkDefinitionRepo
+                .findByEntityTypeAndEntitySubtypeAndActiveTrue(command.entityType(), command.entitySubtype())
+                .orElseThrow(() -> new AssetLinkException(
+                        "Link definition missing for %s/%s".formatted(command.entityType(), command.entitySubtype())));
+    }
+
+    private LinkPersistenceResult persistLink(CreateAssetLinkCommand command) {
+        Optional<AssetLinkEntity> existing = assetLinkRepo.link(
+                command.assetId(), command.entityType(), command.entitySubtype(), command.targetCode());
+        boolean reactivated = existing.filter(link -> !link.isActive()).isPresent();
+
+        AssetLinkEntity entity = existing
+                .map(existingLink -> reactivate(existingLink, command))
+                .orElseGet(() -> newAssetLink(command));
+
+        AssetLinkEntity saved = assetLinkRepo.save(entity);
+        return new LinkPersistenceResult(saved, reactivated);
+    }
+
+    private AssetLinkEntity newAssetLink(CreateAssetLinkCommand command) {
+        return AssetLinkEntity.builder()
+                .assetId(command.assetId())
+                .entityType(command.entityType())
+                .entitySubtype(command.entitySubtype())
+                .targetCode(command.targetCode())
+                .active(true)
+                .createdAt(orNow(command.requestTime()))
+                .createdBy(command.executedBy())
+                .build();
+    }
+
+    private AssetLinkEntity requireActiveLink(DeleteAssetLinkCommand command) {
+        return assetLinkRepo
+                .activeLink(
+                        command.assetId(), command.entityType(), command.entitySubtype(), command.targetCode())
+                .orElseThrow(() -> new AssetLinkException(
+                        "Active link not found for asset %s".formatted(command.assetId())));
+    }
+
+    private void deactivateLink(DeleteAssetLinkCommand command, AssetLinkEntity entity) {
+        entity.setActive(false);
+        entity.setDeactivatedAt(orNow(command.requestTime()));
+        entity.setDeactivatedBy(command.executedBy());
+        assetLinkRepo.save(entity);
+    }
+
+    private record LinkPersistenceResult(AssetLinkEntity entity, boolean reactivated) {
+    }
+
+    private AssetLinkEntity reactivate(AssetLinkEntity entity, CreateAssetLinkCommand command) {
+        if (entity.isActive()) {
+            throw new AssetLinkException(
+                    "Active link already exists for asset %s and target %s".formatted(
+                            command.assetId(), command.targetCode()));
+        }
+        entity.setActive(true);
+        entity.setCreatedAt(orNow(command.requestTime()));
+        entity.setCreatedBy(command.executedBy());
+        entity.setDeactivatedAt(null);
+        entity.setDeactivatedBy(null);
+        return entity;
+    }
+
 }

--- a/src/main/java/com/db/assetstore/infra/service/AssetLinkQueryServiceImpl.java
+++ b/src/main/java/com/db/assetstore/infra/service/AssetLinkQueryServiceImpl.java
@@ -1,0 +1,40 @@
+package com.db.assetstore.infra.service;
+
+import com.db.assetstore.domain.model.link.AssetLink;
+import com.db.assetstore.domain.service.link.AssetLinkQueryService;
+import com.db.assetstore.infra.jpa.AssetLinkEntity;
+import com.db.assetstore.infra.mapper.AssetLinkMapper;
+import com.db.assetstore.infra.repository.AssetLinkRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AssetLinkQueryServiceImpl implements AssetLinkQueryService {
+
+    private final AssetLinkRepo assetLinkRepo;
+    private final AssetLinkMapper assetLinkMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AssetLink> findActiveLinks(String assetId) {
+        return toModelList(assetLinkRepo.activeForAsset(assetId));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AssetLink> findLinks(String assetId, boolean includeInactive) {
+        if (includeInactive) {
+            return toModelList(assetLinkRepo.allForAsset(assetId));
+        }
+        return findActiveLinks(assetId);
+    }
+
+    private List<AssetLink> toModelList(List<AssetLinkEntity> entities) {
+        List<AssetLink> mapped = assetLinkMapper.toModelList(entities);
+        return mapped == null ? List.of() : List.copyOf(mapped);
+    }
+}

--- a/src/main/java/com/db/assetstore/infra/service/AssetQueryServiceImpl.java
+++ b/src/main/java/com/db/assetstore/infra/service/AssetQueryServiceImpl.java
@@ -21,11 +21,11 @@ public class AssetQueryServiceImpl implements AssetQueryService {
     private final AssetMapper assetMapper;
     private final AssetRepository assetRepo;
     private final AssetSearchSpecificationService specService;
-
     @Override
     @Transactional(readOnly = true)
     public Optional<Asset> get(String id) {
-        return assetRepo.findByIdAndDeleted(id, 0).map(assetMapper::toModel);
+        return assetRepo.findByIdAndDeleted(id, 0)
+                .map(assetMapper::toModel);
     }
 
     @Override
@@ -38,4 +38,5 @@ public class AssetQueryServiceImpl implements AssetQueryService {
     private List<AssetEntity> searchEntities(SearchCriteria criteria) {
         return assetRepo.findAll(specService.buildSpec(criteria));
     }
+
 }

--- a/src/main/java/com/db/assetstore/infra/service/link/AssetLinkCommandValidator.java
+++ b/src/main/java/com/db/assetstore/infra/service/link/AssetLinkCommandValidator.java
@@ -1,0 +1,62 @@
+package com.db.assetstore.infra.service.link;
+
+import com.db.assetstore.domain.model.link.LinkCardinality;
+import com.db.assetstore.domain.service.link.AssetLinkException;
+import com.db.assetstore.domain.service.link.cmd.CreateAssetLinkCommand;
+import com.db.assetstore.infra.jpa.AssetLinkEntity;
+import com.db.assetstore.infra.jpa.LinkDefinitionEntity;
+import com.db.assetstore.infra.repository.AssetLinkRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class AssetLinkCommandValidator {
+
+    private final AssetLinkRepo assetLinkRepo;
+
+    public void validateCreate(CreateAssetLinkCommand command, LinkDefinitionEntity definition) {
+        ensureDefinitionActive(definition);
+        ensureNoDuplicate(command);
+        ensureCardinality(definition.getCardinality(), command);
+    }
+
+    private void ensureDefinitionActive(LinkDefinitionEntity definition) {
+        if (!definition.isActive()) {
+            throw new AssetLinkException(
+                    "Link definition %s/%s is inactive".formatted(
+                            definition.getEntityType(), definition.getEntitySubtype()));
+        }
+    }
+
+    private void ensureNoDuplicate(CreateAssetLinkCommand command) {
+        assetLinkRepo.activeLink(
+                        command.assetId(), command.entityType(), command.entitySubtype(), command.targetCode())
+                .ifPresent(existing -> {
+                    throw new AssetLinkException(
+                            "Active link already exists for asset %s and target %s".formatted(
+                                    command.assetId(), command.targetCode()));
+                });
+    }
+
+    private void ensureCardinality(LinkCardinality cardinality, CreateAssetLinkCommand command) {
+        List<AssetLinkEntity> assetLinks = assetLinkRepo
+                .activeForAssetType(command.assetId(), command.entityType(), command.entitySubtype());
+        List<AssetLinkEntity> targetLinks = assetLinkRepo
+                .activeForTarget(command.entityType(), command.entitySubtype(), command.targetCode());
+
+        if (cardinality.limitsAssetSide() && !assetLinks.isEmpty()) {
+            throw new AssetLinkException(
+                    "Asset %s already has an active link for %s/%s".formatted(
+                            command.assetId(), command.entityType(), command.entitySubtype()));
+        }
+        if (cardinality.limitsTargetSide() && !targetLinks.isEmpty()) {
+            throw new AssetLinkException(
+                    "Target %s already linked for %s/%s".formatted(
+                            command.targetCode(), command.entityType(), command.entitySubtype()));
+        }
+    }
+}
+

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -146,4 +146,121 @@
             <column name="command_type"/>
         </createIndex>
     </changeSet>
+
+    <changeSet id="8-link-definition" author="assistant">
+        <createTable tableName="link_definition">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="entity_type" type="varchar(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="entity_subtype" type="varchar(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cardinality" type="varchar(32)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="active" type="boolean" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addUniqueConstraint tableName="link_definition"
+                             columnNames="entity_type,entity_subtype"
+                             constraintName="uk_link_definition_type_subtype"/>
+    </changeSet>
+
+    <changeSet id="9-asset-link" author="assistant">
+        <createTable tableName="asset_link">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="asset_id" type="varchar(36)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="entity_type" type="varchar(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="entity_subtype" type="varchar(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="target_code" type="varchar(128)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="active" type="boolean" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="timestamp"/>
+            <column name="created_by" type="varchar(64)"/>
+            <column name="deactivated_at" type="timestamp"/>
+            <column name="deactivated_by" type="varchar(64)"/>
+        </createTable>
+        <addUniqueConstraint tableName="asset_link"
+                             columnNames="asset_id,entity_type,entity_subtype,target_code"
+                             constraintName="uk_asset_link_unique"/>
+        <addForeignKeyConstraint baseTableName="asset_link" baseColumnNames="asset_id"
+                                  referencedTableName="assets" referencedColumnNames="id"
+                                  constraintName="fk_asset_link_asset"/>
+        <createIndex tableName="asset_link" indexName="idx_asset_link_asset">
+            <column name="asset_id"/>
+        </createIndex>
+        <createIndex tableName="asset_link" indexName="idx_asset_link_target">
+            <column name="entity_type"/>
+            <column name="entity_subtype"/>
+            <column name="target_code"/>
+            <column name="active"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="10-link-definition-seed" author="assistant">
+        <insert tableName="link_definition">
+            <column name="entity_type" value="WORKFLOW"/>
+            <column name="entity_subtype" value="BULK"/>
+            <column name="cardinality" value="ASSET_ONE_TARGET_ONE"/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="link_definition">
+            <column name="entity_type" value="WORKFLOW"/>
+            <column name="entity_subtype" value="MONITORING"/>
+            <column name="cardinality" value="ASSET_ONE_TARGET_ONE"/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="link_definition">
+            <column name="entity_type" value="WORKFLOW"/>
+            <column name="entity_subtype" value="REVALUATION"/>
+            <column name="cardinality" value="ASSET_ONE_TARGET_ONE"/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="link_definition">
+            <column name="entity_type" value="WORKFLOW"/>
+            <column name="entity_subtype" value="CHG"/>
+            <column name="cardinality" value="ASSET_ONE_TARGET_ONE"/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="link_definition">
+            <column name="entity_type" value="INSTRUMENT"/>
+            <column name="entity_subtype" value="BULK"/>
+            <column name="cardinality" value="ASSET_ONE_TARGET_ONE"/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="link_definition">
+            <column name="entity_type" value="INSTRUMENT"/>
+            <column name="entity_subtype" value="MONITORING"/>
+            <column name="cardinality" value="ASSET_ONE_TARGET_ONE"/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="link_definition">
+            <column name="entity_type" value="INSTRUMENT"/>
+            <column name="entity_subtype" value="REVALUATION"/>
+            <column name="cardinality" value="ASSET_ONE_TARGET_ONE"/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="link_definition">
+            <column name="entity_type" value="INSTRUMENT"/>
+            <column name="entity_subtype" value="CHG"/>
+            <column name="cardinality" value="ASSET_ONE_TARGET_ONE"/>
+            <column name="active" valueBoolean="true"/>
+        </insert>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/com/db/assetstore/infra/service/AssetLinkCommandDataTest.java
+++ b/src/test/java/com/db/assetstore/infra/service/AssetLinkCommandDataTest.java
@@ -1,0 +1,329 @@
+package com.db.assetstore.infra.service;
+
+import com.db.assetstore.domain.model.link.LinkCardinality;
+import com.db.assetstore.domain.service.cmd.CommandResult;
+import com.db.assetstore.domain.service.link.AssetLinkException;
+import com.db.assetstore.domain.service.link.cmd.CreateAssetLinkCommand;
+import com.db.assetstore.domain.service.link.cmd.DeleteAssetLinkCommand;
+import com.db.assetstore.infra.config.JsonMapperProvider;
+import com.db.assetstore.infra.jpa.AssetLinkEntity;
+import com.db.assetstore.infra.jpa.LinkDefinitionEntity;
+import com.db.assetstore.infra.mapper.AssetMapper;
+import com.db.assetstore.infra.mapper.AssetMapperImpl;
+import com.db.assetstore.infra.mapper.AttributeMapper;
+import com.db.assetstore.infra.mapper.AttributesCollectionMapper;
+import com.db.assetstore.infra.repository.AssetLinkRepo;
+import com.db.assetstore.infra.repository.AssetRepository;
+import com.db.assetstore.infra.repository.AttributeRepository;
+import com.db.assetstore.infra.repository.CommandLogRepository;
+import com.db.assetstore.infra.repository.LinkDefinitionRepo;
+import com.db.assetstore.infra.service.link.AssetLinkCommandValidator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@Import(AssetLinkCommandValidator.class)
+class AssetLinkCommandDataTest {
+
+    @Autowired
+    AssetLinkRepo assetLinkRepo;
+
+    @Autowired
+    LinkDefinitionRepo linkDefinitionRepo;
+
+    @Autowired
+    CommandLogRepository commandLogRepository;
+
+    @Autowired
+    AssetRepository assetRepository;
+
+    @Autowired
+    AttributeRepository attributeRepository;
+
+    @Autowired
+    AssetLinkCommandValidator assetLinkCommandValidator;
+
+    AssetCommandServiceImpl service;
+
+    ObjectMapper objectMapper = new JsonMapperProvider().objectMapper();
+
+    @BeforeEach
+    void setUp() {
+        AttributesCollectionMapper collectionMapper = Mappers.getMapper(AttributesCollectionMapper.class);
+        AssetMapper assetMapper = new AssetMapperImpl(collectionMapper);
+        AttributeMapper attributeMapper = Mappers.getMapper(AttributeMapper.class);
+
+        service = new AssetCommandServiceImpl(
+                assetMapper,
+                attributeMapper,
+                assetRepository,
+                attributeRepository,
+                commandLogRepository,
+                assetLinkRepo,
+                linkDefinitionRepo,
+                assetLinkCommandValidator,
+                objectMapper
+        );
+    }
+
+    @Test
+    void createLink_reactivatesExistingRowInsteadOfInserting() {
+        linkDefinitionRepo.save(LinkDefinitionEntity.builder()
+                .entityType("WORKFLOW")
+                .entitySubtype("BULK")
+                .cardinality(LinkCardinality.ASSET_ONE_TARGET_ONE)
+                .active(true)
+                .build());
+
+        CreateAssetLinkCommand command = CreateAssetLinkCommand.builder()
+                .assetId("asset-1")
+                .entityType("WORKFLOW")
+                .entitySubtype("BULK")
+                .targetCode("WF-42")
+                .executedBy("tester")
+                .requestTime(Instant.parse("2024-01-01T00:00:00Z"))
+                .build();
+
+        CommandResult<Long> first = service.execute(command);
+        assertThat(first.success()).isTrue();
+
+        service.execute(DeleteAssetLinkCommand.builder()
+                .assetId("asset-1")
+                .entityType("WORKFLOW")
+                .entitySubtype("BULK")
+                .targetCode("WF-42")
+                .executedBy("tester")
+                .requestTime(Instant.parse("2024-01-02T00:00:00Z"))
+                .build());
+
+        AssetLinkEntity deactivated = assetLinkRepo.findById(first.result()).orElseThrow();
+        assertThat(deactivated.isActive()).isFalse();
+        assertThat(deactivated.getDeactivatedAt()).isNotNull();
+
+        CommandResult<Long> second = service.execute(command);
+
+        assertThat(second.result()).isEqualTo(first.result());
+        assertThat(assetLinkRepo.count()).isEqualTo(1L);
+
+        AssetLinkEntity reactivated = assetLinkRepo.findById(second.result()).orElseThrow();
+        assertThat(reactivated.isActive()).isTrue();
+        assertThat(reactivated.getDeactivatedAt()).isNull();
+        assertThat(reactivated.getDeactivatedBy()).isNull();
+    }
+
+    @Test
+    void deleteLink_marksLinkInactive() {
+        linkDefinitionRepo.save(LinkDefinitionEntity.builder()
+                .entityType("WORKFLOW")
+                .entitySubtype("REVALUATION")
+                .cardinality(LinkCardinality.ASSET_ONE_TARGET_ONE)
+                .active(true)
+                .build());
+
+        CreateAssetLinkCommand create = CreateAssetLinkCommand.builder()
+                .assetId("asset-1")
+                .entityType("WORKFLOW")
+                .entitySubtype("REVALUATION")
+                .targetCode("WF-77")
+                .executedBy("tester")
+                .requestTime(Instant.parse("2024-01-05T00:00:00Z"))
+                .build();
+
+        CommandResult<Long> result = service.execute(create);
+        assertThat(result.success()).isTrue();
+
+        DeleteAssetLinkCommand delete = DeleteAssetLinkCommand.builder()
+                .assetId("asset-1")
+                .entityType("WORKFLOW")
+                .entitySubtype("REVALUATION")
+                .targetCode("WF-77")
+                .executedBy("auditor")
+                .requestTime(Instant.parse("2024-01-06T00:00:00Z"))
+                .build();
+
+        CommandResult<Void> deleteResult = service.execute(delete);
+        assertThat(deleteResult.success()).isTrue();
+
+        AssetLinkEntity entity = assetLinkRepo.findById(result.result()).orElseThrow();
+        assertThat(entity.isActive()).isFalse();
+        assertThat(entity.getDeactivatedBy()).isEqualTo("auditor");
+        assertThat(entity.getDeactivatedAt()).isEqualTo(Instant.parse("2024-01-06T00:00:00Z"));
+    }
+
+    @Test
+    void createLink_respectsTargetSideCardinality() {
+        linkDefinitionRepo.save(LinkDefinitionEntity.builder()
+                .entityType("WORKFLOW")
+                .entitySubtype("MONITORING")
+                .cardinality(LinkCardinality.ASSET_MANY_TARGET_ONE)
+                .active(true)
+                .build());
+
+        CreateAssetLinkCommand first = CreateAssetLinkCommand.builder()
+                .assetId("asset-1")
+                .entityType("WORKFLOW")
+                .entitySubtype("MONITORING")
+                .targetCode("WF-99")
+                .executedBy("tester")
+                .requestTime(Instant.parse("2024-01-03T00:00:00Z"))
+                .build();
+
+        CreateAssetLinkCommand second = CreateAssetLinkCommand.builder()
+                .assetId("asset-2")
+                .entityType("WORKFLOW")
+                .entitySubtype("MONITORING")
+                .targetCode("WF-99")
+                .executedBy("tester")
+                .requestTime(Instant.parse("2024-01-04T00:00:00Z"))
+                .build();
+
+        assertThat(service.execute(first).success()).isTrue();
+
+        assertThatThrownBy(() -> service.execute(second))
+                .isInstanceOf(AssetLinkException.class)
+                .hasMessageContaining("Target WF-99 already linked");
+    }
+
+    @Test
+    void oneToMany_allowsMultipleLinksForAsset() {
+        linkDefinitionRepo.save(LinkDefinitionEntity.builder()
+                .entityType("WORKFLOW")
+                .entitySubtype("CHG")
+                .cardinality(LinkCardinality.ASSET_MANY_TARGET_ONE)
+                .active(true)
+                .build());
+
+        CreateAssetLinkCommand first = CreateAssetLinkCommand.builder()
+                .assetId("asset-1")
+                .entityType("WORKFLOW")
+                .entitySubtype("CHG")
+                .targetCode("WF-101")
+                .executedBy("tester")
+                .requestTime(Instant.parse("2024-01-07T00:00:00Z"))
+                .build();
+
+        CreateAssetLinkCommand second = CreateAssetLinkCommand.builder()
+                .assetId("asset-1")
+                .entityType("WORKFLOW")
+                .entitySubtype("CHG")
+                .targetCode("WF-102")
+                .executedBy("tester")
+                .requestTime(Instant.parse("2024-01-08T00:00:00Z"))
+                .build();
+
+        assertThat(service.execute(first).success()).isTrue();
+        assertThat(service.execute(second).success()).isTrue();
+
+        assertThat(assetLinkRepo.activeForAssetType("asset-1", "WORKFLOW", "CHG"))
+                .extracting(AssetLinkEntity::getTargetCode)
+                .containsExactlyInAnyOrder("WF-101", "WF-102");
+    }
+
+    @Test
+    void oneToOne_limitsBothSides() {
+        linkDefinitionRepo.save(LinkDefinitionEntity.builder()
+                .entityType("WORKFLOW")
+                .entitySubtype("BULK")
+                .cardinality(LinkCardinality.ASSET_ONE_TARGET_ONE)
+                .active(true)
+                .build());
+
+        CreateAssetLinkCommand first = CreateAssetLinkCommand.builder()
+                .assetId("asset-1")
+                .entityType("WORKFLOW")
+                .entitySubtype("BULK")
+                .targetCode("WF-1")
+                .executedBy("tester")
+                .requestTime(Instant.parse("2024-01-09T00:00:00Z"))
+                .build();
+
+        assertThat(service.execute(first).success()).isTrue();
+
+        CreateAssetLinkCommand second = CreateAssetLinkCommand.builder()
+                .assetId("asset-1")
+                .entityType("WORKFLOW")
+                .entitySubtype("BULK")
+                .targetCode("WF-2")
+                .executedBy("tester")
+                .requestTime(Instant.parse("2024-01-10T00:00:00Z"))
+                .build();
+
+        assertThatThrownBy(() -> service.execute(second))
+                .isInstanceOf(AssetLinkException.class)
+                .hasMessageContaining("Asset asset-1 already has an active link for WORKFLOW/BULK");
+
+        CreateAssetLinkCommand third = CreateAssetLinkCommand.builder()
+                .assetId("asset-2")
+                .entityType("WORKFLOW")
+                .entitySubtype("BULK")
+                .targetCode("WF-1")
+                .executedBy("tester")
+                .requestTime(Instant.parse("2024-01-11T00:00:00Z"))
+                .build();
+
+        assertThatThrownBy(() -> service.execute(third))
+                .isInstanceOf(AssetLinkException.class)
+                .hasMessageContaining("Target WF-1 already linked for WORKFLOW/BULK");
+    }
+
+    @Test
+    void manyToOne_limitsAssetSideOnly() {
+        linkDefinitionRepo.save(LinkDefinitionEntity.builder()
+                .entityType("INSTRUMENT")
+                .entitySubtype("MONITORING")
+                .cardinality(LinkCardinality.ASSET_ONE_TARGET_MANY)
+                .active(true)
+                .build());
+
+        CreateAssetLinkCommand first = CreateAssetLinkCommand.builder()
+                .assetId("asset-1")
+                .entityType("INSTRUMENT")
+                .entitySubtype("MONITORING")
+                .targetCode("INST-1")
+                .executedBy("tester")
+                .requestTime(Instant.parse("2024-01-12T00:00:00Z"))
+                .build();
+
+        assertThat(service.execute(first).success()).isTrue();
+
+        CreateAssetLinkCommand second = CreateAssetLinkCommand.builder()
+                .assetId("asset-1")
+                .entityType("INSTRUMENT")
+                .entitySubtype("MONITORING")
+                .targetCode("INST-2")
+                .executedBy("tester")
+                .requestTime(Instant.parse("2024-01-13T00:00:00Z"))
+                .build();
+
+        assertThatThrownBy(() -> service.execute(second))
+                .isInstanceOf(AssetLinkException.class)
+                .hasMessageContaining("Asset asset-1 already has an active link for INSTRUMENT/MONITORING");
+
+        CreateAssetLinkCommand third = CreateAssetLinkCommand.builder()
+                .assetId("asset-2")
+                .entityType("INSTRUMENT")
+                .entitySubtype("MONITORING")
+                .targetCode("INST-1")
+                .executedBy("tester")
+                .requestTime(Instant.parse("2024-01-14T00:00:00Z"))
+                .build();
+
+        assertThat(service.execute(third).success()).isTrue();
+
+        assertThat(assetLinkRepo.activeForTarget("INSTRUMENT", "MONITORING", "INST-1"))
+                .extracting(AssetLinkEntity::getAssetId)
+                .containsExactlyInAnyOrder("asset-1", "asset-2");
+    }
+
+}


### PR DESCRIPTION
## Summary
- add an AssetLinkException runtime type for asset-link domain validation failures
- raise AssetLinkException from the command service and validator instead of IllegalStateException when link checks fail
- update the data-driven asset link tests to assert the new exception type

## Testing
- `mvn -q -DskipTests package` *(fails: cannot resolve Spring Boot parent because Maven Central is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e9e91a0083308d5629d2b64580de