### PR TITLE
Fix attribute history lazy initialization during updates

### DIFF
--- a/src/main/java/com/db/assetstore/infra/service/AssetService.java
+++ b/src/main/java/com/db/assetstore/infra/service/AssetService.java
@@ -120,7 +120,7 @@ public class AssetService {
         if (patch.currency() != null) entity.setCurrency(patch.currency());
         entity.setModifiedBy(executedBy);
         entity.setModifiedAt(Instant.now());
-        assetRepo.save(entity);
+        entity = assetRepo.save(entity);
 
         if (patch.attributes() != null) {
             updateAsset(entity, patch.attributes());
@@ -160,10 +160,14 @@ public class AssetService {
                 attributeRepo.save(created);
                 existing.put(created.getName(), created);
             } else {
-                AttributeValue<?> currentValue = attributeMapper.toModel(current);
+                AttributeEntity managed = attributeRepo.findById(current.getId())
+                        .orElse(current);
+                existing.put(managed.getName(), managed);
+
+                AttributeValue<?> currentValue = attributeMapper.toModel(managed);
                 if (AttributeComparator.checkforUpdates(currentValue, incoming)) {
-                    AttributeUpdater.apply(current, incoming);
-                    attributeRepo.save(current);
+                    AttributeUpdater.apply(managed, incoming);
+                    attributeRepo.save(managed);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- ensure the asset entity returned from save is reused before attribute updates
- reload managed AttributeEntity instances before appending history so lazy collections stay attached

## Testing
- `mvn -q -Dtest=AssetControllerTest test` *(fails: parent POM cannot be resolved without network access)*

------
https://chatgpt.com/codex/tasks/task_e_68d547781db883309a8e46d8b9fa0add