### PR TITLE
Simplify domain exceptions and improve error mapping

### DIFF
--- a/src/main/java/com/db/assetstore/domain/exception/CanonicalizationException.java
+++ b/src/main/java/com/db/assetstore/domain/exception/CanonicalizationException.java
@@ -1,0 +1,7 @@
+package com.db.assetstore.domain.exception;
+
+public class CanonicalizationException extends JsonException {
+    public CanonicalizationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/db/assetstore/domain/exception/DomainException.java
+++ b/src/main/java/com/db/assetstore/domain/exception/DomainException.java
@@ -1,0 +1,11 @@
+package com.db.assetstore.domain.exception;
+
+public class DomainException extends Exception {
+    public DomainException(String message) {
+        super(message);
+    }
+
+    public DomainException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/db/assetstore/domain/exception/EventGenerationException.java
+++ b/src/main/java/com/db/assetstore/domain/exception/EventGenerationException.java
@@ -1,0 +1,7 @@
+package com.db.assetstore.domain.exception;
+
+public class EventGenerationException extends JsonException {
+    public EventGenerationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/db/assetstore/domain/exception/JsonException.java
+++ b/src/main/java/com/db/assetstore/domain/exception/JsonException.java
@@ -1,0 +1,11 @@
+package com.db.assetstore.domain.exception;
+
+public abstract class JsonException extends DomainException {
+    protected JsonException(String message) {
+        super(message);
+    }
+
+    protected JsonException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/db/assetstore/domain/exception/JsonTransformException.java
+++ b/src/main/java/com/db/assetstore/domain/exception/JsonTransformException.java
@@ -1,0 +1,11 @@
+package com.db.assetstore.domain.exception;
+
+public class JsonTransformException extends JsonException {
+    public JsonTransformException(String message) {
+        super(message);
+    }
+
+    public JsonTransformException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/db/assetstore/domain/exception/TransformSchemaValidationException.java
+++ b/src/main/java/com/db/assetstore/domain/exception/TransformSchemaValidationException.java
@@ -1,0 +1,7 @@
+package com.db.assetstore.domain.exception;
+
+public class TransformSchemaValidationException extends JsonTransformException {
+    public TransformSchemaValidationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/db/assetstore/domain/exception/TransformTemplateNotFoundException.java
+++ b/src/main/java/com/db/assetstore/domain/exception/TransformTemplateNotFoundException.java
@@ -1,0 +1,7 @@
+package com.db.assetstore.domain.exception;
+
+public class TransformTemplateNotFoundException extends JsonTransformException {
+    public TransformTemplateNotFoundException(String templatePath) {
+        super("Transform template not found: " + templatePath);
+    }
+}

--- a/src/main/java/com/db/assetstore/domain/exception/command/CommandException.java
+++ b/src/main/java/com/db/assetstore/domain/exception/command/CommandException.java
@@ -1,0 +1,13 @@
+package com.db.assetstore.domain.exception.command;
+
+import com.db.assetstore.domain.exception.DomainException;
+
+public abstract class CommandException extends DomainException {
+    protected CommandException(String message) {
+        super(message);
+    }
+
+    protected CommandException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/db/assetstore/domain/exception/link/ActiveLinkNotFoundException.java
+++ b/src/main/java/com/db/assetstore/domain/exception/link/ActiveLinkNotFoundException.java
@@ -1,0 +1,7 @@
+package com.db.assetstore.domain.exception.link;
+
+public class ActiveLinkNotFoundException extends LinkException {
+    public ActiveLinkNotFoundException(Long linkId) {
+        super("Active link not found: " + linkId);
+    }
+}

--- a/src/main/java/com/db/assetstore/domain/exception/link/InactiveLinkDefinitionException.java
+++ b/src/main/java/com/db/assetstore/domain/exception/link/InactiveLinkDefinitionException.java
@@ -1,0 +1,7 @@
+package com.db.assetstore.domain.exception.link;
+
+public class InactiveLinkDefinitionException extends LinkException {
+    public InactiveLinkDefinitionException(String entityType, String entitySubtype) {
+        super("Link definition inactive for %s/%s".formatted(entityType, entitySubtype));
+    }
+}

--- a/src/main/java/com/db/assetstore/domain/exception/link/LinkAlreadyExistsException.java
+++ b/src/main/java/com/db/assetstore/domain/exception/link/LinkAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package com.db.assetstore.domain.exception.link;
+
+public class LinkAlreadyExistsException extends LinkException {
+    public LinkAlreadyExistsException(String assetId, String targetCode) {
+        super("Active link already exists for asset %s and target %s".formatted(assetId, targetCode));
+    }
+}

--- a/src/main/java/com/db/assetstore/domain/exception/link/LinkCardinalityViolationException.java
+++ b/src/main/java/com/db/assetstore/domain/exception/link/LinkCardinalityViolationException.java
@@ -1,0 +1,7 @@
+package com.db.assetstore.domain.exception.link;
+
+public class LinkCardinalityViolationException extends LinkException {
+    public LinkCardinalityViolationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/db/assetstore/domain/exception/link/LinkDefinitionNotFoundException.java
+++ b/src/main/java/com/db/assetstore/domain/exception/link/LinkDefinitionNotFoundException.java
@@ -1,0 +1,7 @@
+package com.db.assetstore.domain.exception.link;
+
+public class LinkDefinitionNotFoundException extends LinkException {
+    public LinkDefinitionNotFoundException(String entityType, String entitySubtype) {
+        super("Link definition missing for %s/%s".formatted(entityType, entitySubtype));
+    }
+}

--- a/src/main/java/com/db/assetstore/domain/exception/link/LinkException.java
+++ b/src/main/java/com/db/assetstore/domain/exception/link/LinkException.java
@@ -1,0 +1,13 @@
+package com.db.assetstore.domain.exception.link;
+
+import com.db.assetstore.domain.exception.command.CommandException;
+
+public abstract class LinkException extends CommandException {
+    protected LinkException(String message) {
+        super(message);
+    }
+
+    protected LinkException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/db/assetstore/domain/json/AssetCanonicalizer.java
+++ b/src/main/java/com/db/assetstore/domain/json/AssetCanonicalizer.java
@@ -1,5 +1,6 @@
 package com.db.assetstore.domain.json;
 
+import com.db.assetstore.domain.exception.CanonicalizationException;
 import com.db.assetstore.domain.model.Asset;
 import com.db.assetstore.domain.model.attribute.AttributeValue;
 import com.db.assetstore.domain.model.attribute.AttributeValueVisitor;
@@ -19,7 +20,7 @@ public final class AssetCanonicalizer {
 
     private final ObjectMapper mapper;
 
-    public String toCanonicalJson(Asset asset) {
+    public String toCanonicalJson(Asset asset) throws CanonicalizationException {
         ObjectNode root = mapper.createObjectNode();
         put(root, "id", asset.getId());
         put(root, "type", asset.getType());
@@ -48,7 +49,8 @@ public final class AssetCanonicalizer {
         try {
             return mapper.writeValueAsString(root);
         } catch (JsonProcessingException e) {
-            throw new IllegalStateException("Failed to serialize canonical asset JSON", e);
+            throw new CanonicalizationException(
+                    "Failed to serialize canonical asset JSON for asset " + asset.getId(), e);
         }
     }
 

--- a/src/main/java/com/db/assetstore/domain/service/AssetCommandService.java
+++ b/src/main/java/com/db/assetstore/domain/service/AssetCommandService.java
@@ -1,5 +1,6 @@
 package com.db.assetstore.domain.service;
 
+import com.db.assetstore.domain.exception.command.CommandException;
 import com.db.assetstore.domain.service.cmd.AssetCommand;
 import com.db.assetstore.domain.service.cmd.CommandResult;
 import com.db.assetstore.domain.service.cmd.CreateAssetCommand;
@@ -8,17 +9,17 @@ import com.db.assetstore.domain.service.cmd.PatchAssetCommand;
 
 public interface AssetCommandService {
 
-    <R> CommandResult<R> execute(AssetCommand<R> command);
+    <R> CommandResult<R> execute(AssetCommand<R> command) throws CommandException;
 
-    default String create(CreateAssetCommand command) {
+    default String create(CreateAssetCommand command) throws CommandException {
         return execute(command).result();
     }
 
-    default void update(PatchAssetCommand command) {
+    default void update(PatchAssetCommand command) throws CommandException {
         execute(command);
     }
 
-    default void delete(DeleteAssetCommand command) {
+    default void delete(DeleteAssetCommand command) throws CommandException {
         execute(command);
     }
 }

--- a/src/main/java/com/db/assetstore/domain/service/cmd/AssetCommand.java
+++ b/src/main/java/com/db/assetstore/domain/service/cmd/AssetCommand.java
@@ -1,5 +1,7 @@
 package com.db.assetstore.domain.service.cmd;
 
+import com.db.assetstore.domain.exception.command.CommandException;
+
 import java.util.Objects;
 
 /**
@@ -14,7 +16,7 @@ public interface AssetCommand<R> {
      * @param visitor visitor handling the execution for the command type
      * @return command result produced by the visitor
      */
-    CommandResult<R> accept(AssetCommandVisitor visitor);
+    CommandResult<R> accept(AssetCommandVisitor visitor) throws CommandException;
 
     /**
      * Returns the logical name of the command.

--- a/src/main/java/com/db/assetstore/domain/service/cmd/AssetCommandVisitor.java
+++ b/src/main/java/com/db/assetstore/domain/service/cmd/AssetCommandVisitor.java
@@ -1,17 +1,18 @@
 package com.db.assetstore.domain.service.cmd;
 
+import com.db.assetstore.domain.exception.command.CommandException;
 import com.db.assetstore.domain.service.link.cmd.CreateAssetLinkCommand;
 import com.db.assetstore.domain.service.link.cmd.DeleteAssetLinkCommand;
 
 public interface AssetCommandVisitor {
 
-    CommandResult<String> visit(CreateAssetCommand command);
+    CommandResult<String> visit(CreateAssetCommand command) throws CommandException;
 
-    CommandResult<Void> visit(PatchAssetCommand command);
+    CommandResult<Void> visit(PatchAssetCommand command) throws CommandException;
 
-    CommandResult<Void> visit(DeleteAssetCommand command);
+    CommandResult<Void> visit(DeleteAssetCommand command) throws CommandException;
 
-    CommandResult<Long> visit(CreateAssetLinkCommand command);
+    CommandResult<Long> visit(CreateAssetLinkCommand command) throws CommandException;
 
-    CommandResult<Void> visit(DeleteAssetLinkCommand command);
+    CommandResult<Void> visit(DeleteAssetLinkCommand command) throws CommandException;
 }

--- a/src/main/java/com/db/assetstore/domain/service/cmd/CreateAssetCommand.java
+++ b/src/main/java/com/db/assetstore/domain/service/cmd/CreateAssetCommand.java
@@ -1,6 +1,7 @@
 package com.db.assetstore.domain.service.cmd;
 
 import com.db.assetstore.AssetType;
+import com.db.assetstore.domain.exception.command.CommandException;
 import com.db.assetstore.domain.model.attribute.AttributeValue;
 import lombok.Builder;
 
@@ -28,7 +29,7 @@ public record CreateAssetCommand(
 ) implements AssetCommand<String> {
 
     @Override
-    public CommandResult<String> accept(AssetCommandVisitor visitor) {
+    public CommandResult<String> accept(AssetCommandVisitor visitor) throws CommandException {
         return requireVisitor(visitor).visit(this);
     }
 

--- a/src/main/java/com/db/assetstore/domain/service/cmd/DeleteAssetCommand.java
+++ b/src/main/java/com/db/assetstore/domain/service/cmd/DeleteAssetCommand.java
@@ -1,5 +1,6 @@
 package com.db.assetstore.domain.service.cmd;
 
+import com.db.assetstore.domain.exception.command.CommandException;
 import lombok.Builder;
 
 import java.time.Instant;
@@ -15,7 +16,7 @@ public record DeleteAssetCommand(
 ) implements AssetCommand<Void> {
 
     @Override
-    public CommandResult<Void> accept(AssetCommandVisitor visitor) {
+    public CommandResult<Void> accept(AssetCommandVisitor visitor) throws CommandException {
         return requireVisitor(visitor).visit(this);
     }
 

--- a/src/main/java/com/db/assetstore/domain/service/cmd/PatchAssetCommand.java
+++ b/src/main/java/com/db/assetstore/domain/service/cmd/PatchAssetCommand.java
@@ -1,5 +1,6 @@
 package com.db.assetstore.domain.service.cmd;
 
+import com.db.assetstore.domain.exception.command.CommandException;
 import com.db.assetstore.domain.model.attribute.AttributeValue;
 import lombok.Builder;
 
@@ -25,7 +26,7 @@ public record PatchAssetCommand(
 ) implements AssetCommand<Void> {
 
     @Override
-    public CommandResult<Void> accept(AssetCommandVisitor visitor) {
+    public CommandResult<Void> accept(AssetCommandVisitor visitor) throws CommandException {
         return requireVisitor(visitor).visit(this);
     }
 

--- a/src/main/java/com/db/assetstore/domain/service/link/cmd/CreateAssetLinkCommand.java
+++ b/src/main/java/com/db/assetstore/domain/service/link/cmd/CreateAssetLinkCommand.java
@@ -1,5 +1,6 @@
 package com.db.assetstore.domain.service.link.cmd;
 
+import com.db.assetstore.domain.exception.command.CommandException;
 import com.db.assetstore.domain.service.cmd.AssetCommand;
 import com.db.assetstore.domain.service.cmd.AssetCommandVisitor;
 import com.db.assetstore.domain.service.cmd.CommandResult;
@@ -18,7 +19,7 @@ public record CreateAssetLinkCommand(
 ) implements AssetCommand<Long> {
 
     @Override
-    public CommandResult<Long> accept(AssetCommandVisitor visitor) {
+    public CommandResult<Long> accept(AssetCommandVisitor visitor) throws CommandException {
         return AssetCommand.super.requireVisitor(visitor).visit(this);
     }
 }

--- a/src/main/java/com/db/assetstore/domain/service/link/cmd/DeleteAssetLinkCommand.java
+++ b/src/main/java/com/db/assetstore/domain/service/link/cmd/DeleteAssetLinkCommand.java
@@ -1,5 +1,6 @@
 package com.db.assetstore.domain.service.link.cmd;
 
+import com.db.assetstore.domain.exception.command.CommandException;
 import com.db.assetstore.domain.service.cmd.AssetCommand;
 import com.db.assetstore.domain.service.cmd.AssetCommandVisitor;
 import com.db.assetstore.domain.service.cmd.CommandResult;
@@ -18,7 +19,7 @@ public record DeleteAssetLinkCommand(
 ) implements AssetCommand<Void> {
 
     @Override
-    public CommandResult<Void> accept(AssetCommandVisitor visitor) {
+    public CommandResult<Void> accept(AssetCommandVisitor visitor) throws CommandException {
         return AssetCommand.super.requireVisitor(visitor).visit(this);
     }
 }

--- a/src/main/java/com/db/assetstore/infra/api/EventController.java
+++ b/src/main/java/com/db/assetstore/infra/api/EventController.java
@@ -1,9 +1,9 @@
 package com.db.assetstore.infra.api;
 
+import com.db.assetstore.domain.exception.JsonException;
 import com.db.assetstore.domain.model.Asset;
 import com.db.assetstore.domain.service.AssetQueryService;
 import com.db.assetstore.domain.service.EventService;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
@@ -27,7 +27,7 @@ public class EventController {
 
     @GetMapping(path = "/{assetId}/{eventName}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<String> generateEvent(@PathVariable("assetId") String assetId,
-                                                @PathVariable("eventName") String eventName) {
+                                                @PathVariable("eventName") String eventName) throws JsonException {
         log.info("HTTP GET /events/{}/{} - generating event", assetId, eventName);
         Optional<Asset> assetOpt = assetQueryService.get(assetId);
 
@@ -35,12 +35,8 @@ public class EventController {
             return ResponseEntity.notFound().build();
         }
 
-        try {
-            var json = eventService.generate(eventName, assetOpt.get());
-            return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(json);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+        var json = eventService.generate(eventName, assetOpt.get());
+        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(json);
 
     }
 }

--- a/src/main/java/com/db/assetstore/infra/service/link/AssetLinkCommandValidator.java
+++ b/src/main/java/com/db/assetstore/infra/service/link/AssetLinkCommandValidator.java
@@ -1,5 +1,9 @@
 package com.db.assetstore.infra.service.link;
 
+import com.db.assetstore.domain.exception.link.InactiveLinkDefinitionException;
+import com.db.assetstore.domain.exception.link.LinkAlreadyExistsException;
+import com.db.assetstore.domain.exception.link.LinkCardinalityViolationException;
+import com.db.assetstore.domain.exception.link.LinkException;
 import com.db.assetstore.domain.model.link.LinkCardinality;
 import com.db.assetstore.domain.service.link.cmd.CreateAssetLinkCommand;
 import com.db.assetstore.infra.jpa.AssetLinkEntity;
@@ -16,43 +20,42 @@ public class AssetLinkCommandValidator {
 
     private final AssetLinkRepo assetLinkRepo;
 
-    public void validateCreate(CreateAssetLinkCommand command, LinkDefinitionEntity definition) {
+    public void validateCreate(CreateAssetLinkCommand command, LinkDefinitionEntity definition)
+            throws LinkException {
         ensureDefinitionActive(definition);
         ensureNoDuplicate(command);
         ensureCardinality(definition.getCardinality(), command);
     }
 
-    private void ensureDefinitionActive(LinkDefinitionEntity definition) {
+    private void ensureDefinitionActive(LinkDefinitionEntity definition) throws InactiveLinkDefinitionException {
         if (!definition.isActive()) {
-            throw new IllegalStateException(
-                    "Link definition %s/%s is inactive".formatted(
-                            definition.getEntityType(), definition.getEntitySubtype()));
+            throw new InactiveLinkDefinitionException(definition.getEntityType(), definition.getEntitySubtype());
         }
     }
 
-    private void ensureNoDuplicate(CreateAssetLinkCommand command) {
-        assetLinkRepo.activeLink(
+    private void ensureNoDuplicate(CreateAssetLinkCommand command) throws LinkAlreadyExistsException {
+        boolean exists = assetLinkRepo.activeLink(
                         command.assetId(), command.entityType(), command.entitySubtype(), command.targetCode())
-                .ifPresent(existing -> {
-                    throw new IllegalStateException(
-                            "Active link already exists for asset %s and target %s".formatted(
-                                    command.assetId(), command.targetCode()));
-                });
+                .isPresent();
+        if (exists) {
+            throw new LinkAlreadyExistsException(command.assetId(), command.targetCode());
+        }
     }
 
-    private void ensureCardinality(LinkCardinality cardinality, CreateAssetLinkCommand command) {
+    private void ensureCardinality(LinkCardinality cardinality, CreateAssetLinkCommand command)
+            throws LinkCardinalityViolationException {
         List<AssetLinkEntity> assetLinks = assetLinkRepo
                 .activeForAssetType(command.assetId(), command.entityType(), command.entitySubtype());
         List<AssetLinkEntity> targetLinks = assetLinkRepo
                 .activeForTarget(command.entityType(), command.entitySubtype(), command.targetCode());
 
         if (cardinality.limitsAssetSide() && !assetLinks.isEmpty()) {
-            throw new IllegalStateException(
+            throw new LinkCardinalityViolationException(
                     "Asset %s already has an active link for %s/%s".formatted(
                             command.assetId(), command.entityType(), command.entitySubtype()));
         }
         if (cardinality.limitsTargetSide() && !targetLinks.isEmpty()) {
-            throw new IllegalStateException(
+            throw new LinkCardinalityViolationException(
                     "Target %s already linked for %s/%s".formatted(
                             command.targetCode(), command.entityType(), command.entitySubtype()));
         }

--- a/src/test/java/com/db/assetstore/api/AssetControllerTest.java
+++ b/src/test/java/com/db/assetstore/api/AssetControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -52,7 +53,8 @@ class AssetControllerTest {
         MvcResult result = mockMvc.perform(post("/assets")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(payload))
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", not(emptyString())))
                 .andExpect(content().string(not(emptyString())))
                 .andReturn();
 
@@ -91,7 +93,7 @@ class AssetControllerTest {
         MvcResult result = mockMvc.perform(post("/assets")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(payload))
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andReturn();
 
         String assetId = result.getResponse().getContentAsString();
@@ -121,7 +123,8 @@ class AssetControllerTest {
         mockMvc.perform(post("/assets")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(payload))
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", endsWith("/custom-asset-123")))
                 .andExpect(content().string("custom-asset-123"));
 
         mockMvc.perform(get("/assets/custom-asset-123"))
@@ -176,7 +179,7 @@ class AssetControllerTest {
         mockMvc.perform(post("/assets/bulk")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(payload))
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andExpect(jsonPath("$", hasSize(2)))
                 .andExpect(jsonPath("$[0]", is("bulk-cre-1")))
                 .andExpect(jsonPath("$[1]", is("bulk-ship-1")));
@@ -197,7 +200,7 @@ class AssetControllerTest {
         mockMvc.perform(post("/assets/bulk")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("[]"))
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andExpect(jsonPath("$", hasSize(0)));
     }
 
@@ -229,9 +232,9 @@ class AssetControllerTest {
                 """;
 
         mockMvc.perform(post("/assets").contentType(MediaType.APPLICATION_JSON).content(cre))
-                .andExpect(status().isOk());
+                .andExpect(status().isCreated());
         mockMvc.perform(post("/assets").contentType(MediaType.APPLICATION_JSON).content(ship))
-                .andExpect(status().isOk());
+                .andExpect(status().isCreated());
 
         mockMvc.perform(get("/assets")
                         .accept(MediaType.APPLICATION_JSON))
@@ -271,7 +274,7 @@ class AssetControllerTest {
                 """;
 
         mockMvc.perform(post("/assets").contentType(MediaType.APPLICATION_JSON).content(payload))
-                .andExpect(status().isOk());
+                .andExpect(status().isCreated());
 
         mockMvc.perform(get("/assets/get-test-1"))
                 .andExpect(status().isOk())
@@ -308,7 +311,7 @@ class AssetControllerTest {
                 """;
 
         mockMvc.perform(post("/assets").contentType(MediaType.APPLICATION_JSON).content(initialPayload))
-                .andExpect(status().isOk());
+                .andExpect(status().isCreated());
 
         String updatePayload = """
                 {
@@ -373,7 +376,7 @@ class AssetControllerTest {
                 """;
 
         mockMvc.perform(post("/assets").contentType(MediaType.APPLICATION_JSON).content(initialPayload))
-                .andExpect(status().isOk());
+                .andExpect(status().isCreated());
 
         String patchPayload = """
                 {
@@ -430,8 +433,8 @@ class AssetControllerTest {
                 }
                 """;
 
-        mockMvc.perform(post("/assets").contentType(MediaType.APPLICATION_JSON).content(asset1)).andExpect(status().isOk());
-        mockMvc.perform(post("/assets").contentType(MediaType.APPLICATION_JSON).content(asset2)).andExpect(status().isOk());
+        mockMvc.perform(post("/assets").contentType(MediaType.APPLICATION_JSON).content(asset1)).andExpect(status().isCreated());
+        mockMvc.perform(post("/assets").contentType(MediaType.APPLICATION_JSON).content(asset2)).andExpect(status().isCreated());
 
         String bulkPatchPayload = """
                 [
@@ -514,7 +517,7 @@ class AssetControllerTest {
         MvcResult result = mockMvc.perform(post("/assets")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(payload))
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andReturn();
 
         String assetId = result.getResponse().getContentAsString();
@@ -544,7 +547,7 @@ class AssetControllerTest {
         MvcResult result = mockMvc.perform(post("/assets")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(payload))
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andReturn();
 
         String assetId = result.getResponse().getContentAsString();
@@ -572,7 +575,7 @@ class AssetControllerTest {
         MvcResult result = mockMvc.perform(post("/assets")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(payload))
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andReturn();
 
         String assetId = result.getResponse().getContentAsString();

--- a/src/test/java/com/db/assetstore/api/AssetLinkControllerTest.java
+++ b/src/test/java/com/db/assetstore/api/AssetLinkControllerTest.java
@@ -109,7 +109,7 @@ class AssetLinkControllerTest {
         MvcResult result = mockMvc.perform(post("/assets")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(payload))
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andReturn();
 
         return result.getResponse().getContentAsString();

--- a/src/test/java/com/db/assetstore/domain/service/EventServiceTest.java
+++ b/src/test/java/com/db/assetstore/domain/service/EventServiceTest.java
@@ -1,0 +1,69 @@
+package com.db.assetstore.domain.service;
+
+import com.db.assetstore.AssetType;
+import com.db.assetstore.domain.exception.EventGenerationException;
+import com.db.assetstore.domain.exception.JsonTransformException;
+import com.db.assetstore.domain.json.AssetCanonicalizer;
+import com.db.assetstore.domain.model.Asset;
+import com.db.assetstore.domain.service.transform.JsonTransformer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class EventServiceTest {
+
+    JsonTransformer transformer;
+    AssetCanonicalizer canonicalizer;
+    ObjectMapper objectMapper;
+    EventService service;
+
+    @BeforeEach
+    void setUp() {
+        transformer = mock(JsonTransformer.class);
+        canonicalizer = mock(AssetCanonicalizer.class);
+        objectMapper = new ObjectMapper();
+        service = new EventService(transformer, canonicalizer, objectMapper);
+    }
+
+    @Test
+    void generate_whenCanonicalJsonCannotBeParsed_throwsEventGenerationException() throws Exception {
+        Asset asset = Asset.builder()
+                .id("asset-1")
+                .type(AssetType.CRE)
+                .createdAt(Instant.now())
+                .build();
+        asset.setAttributes(List.of());
+
+        when(canonicalizer.toCanonicalJson(any())).thenReturn("not-json");
+
+        assertThatThrownBy(() -> service.generate("asset-cre", asset))
+                .isInstanceOf(EventGenerationException.class)
+                .hasMessageContaining("asset-1")
+                .hasMessageContaining("canonical asset JSON");
+    }
+
+    @Test
+    void generate_whenTransformerThrows_propagatesJsonTransformException() throws Exception {
+        Asset asset = Asset.builder()
+                .id("asset-1")
+                .type(AssetType.CRE)
+                .createdAt(Instant.now())
+                .build();
+        asset.setAttributes(List.of());
+
+        when(canonicalizer.toCanonicalJson(any())).thenReturn("{\"id\":\"asset-1\"}");
+        when(transformer.transform(any(), any())).thenThrow(new JsonTransformException("boom"));
+
+        assertThatThrownBy(() -> service.generate("asset-cre", asset))
+                .isInstanceOf(JsonTransformException.class)
+                .hasMessageContaining("boom");
+    }
+}

--- a/src/test/java/com/db/assetstore/domain/service/transform/JsonTransformerTest.java
+++ b/src/test/java/com/db/assetstore/domain/service/transform/JsonTransformerTest.java
@@ -1,0 +1,60 @@
+package com.db.assetstore.domain.service.transform;
+
+import com.db.assetstore.domain.exception.JsonTransformException;
+import com.db.assetstore.domain.exception.TransformSchemaValidationException;
+import com.db.assetstore.domain.exception.TransformTemplateNotFoundException;
+import com.db.assetstore.domain.service.validation.JsonSchemaValidator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+class JsonTransformerTest {
+
+    ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    void transform_whenTemplateMissing_throwsNotFoundException() {
+        JsonSchemaValidator validator = new JsonSchemaValidator(objectMapper);
+        JsonTransformer transformer = new JsonTransformer(objectMapper, validator);
+
+        assertThatThrownBy(() -> transformer.transform("missing-template", "{}"))
+                .isInstanceOf(TransformTemplateNotFoundException.class)
+                .hasMessageContaining("missing-template");
+    }
+
+    @Test
+    void transform_whenValidatorFails_wrapsIntoSchemaValidationException() {
+        JsonSchemaValidator validator = mock(JsonSchemaValidator.class);
+        JsonTransformer transformer = new JsonTransformer(objectMapper, validator);
+
+        doThrow(new IllegalArgumentException("schema broken"))
+                .when(validator).validateOrThrow(any(String.class), any(String.class));
+
+        String input = "{\"asset\":{\"id\":\"1\",\"type\":\"CRE\"}}";
+
+        assertThatThrownBy(() -> transformer.transform("asset-cre", input))
+                .isInstanceOf(TransformSchemaValidationException.class)
+                .hasMessageContaining("asset-cre")
+                .hasMessageContaining("schema broken");
+    }
+
+    @Test
+    void transform_whenInputJsonInvalid_wrapsAsJsonTransformException() {
+        JsonSchemaValidator validator = new JsonSchemaValidator(objectMapper);
+        JsonTransformer transformer = new JsonTransformer(objectMapper, validator);
+
+        assertThatThrownBy(() -> transformer.transform("asset-cre", "not-json"))
+                .isInstanceOf(JsonTransformException.class)
+                .hasMessageContaining("asset-cre");
+    }
+}

--- a/src/test/java/com/db/assetstore/infra/api/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/db/assetstore/infra/api/GlobalExceptionHandlerTest.java
@@ -1,0 +1,82 @@
+package com.db.assetstore.infra.api;
+
+import com.db.assetstore.domain.exception.EventGenerationException;
+import com.db.assetstore.domain.exception.TransformSchemaValidationException;
+import com.db.assetstore.domain.exception.link.LinkCardinalityViolationException;
+import com.db.assetstore.domain.exception.link.LinkDefinitionNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = GlobalExceptionHandlerTest.TestController.class)
+@Import(GlobalExceptionHandler.class)
+class GlobalExceptionHandlerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    void mapsDomainNotFoundTo404() throws Exception {
+        mockMvc.perform(get("/test/not-found").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.message", containsString("Link definition missing")));
+    }
+
+    @Test
+    void mapsDomainConflictTo409() throws Exception {
+        mockMvc.perform(get("/test/conflict").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.status").value(409))
+                .andExpect(jsonPath("$.message", containsString("Asset asset-1 already has")));
+    }
+
+    @Test
+    void mapsDomainValidationTo422() throws Exception {
+        mockMvc.perform(get("/test/validation").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.status").value(422))
+                .andExpect(jsonPath("$.message", containsString("invalid")));
+    }
+
+    @Test
+    void mapsDomainInternalTo500() throws Exception {
+        mockMvc.perform(get("/test/internal").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.status").value(500))
+                .andExpect(jsonPath("$.message", containsString("boom")));
+    }
+
+    @RestController
+    static class TestController {
+        @GetMapping("/test/not-found")
+        void notFound() throws Exception {
+            throw new LinkDefinitionNotFoundException("WORKFLOW", "BULK");
+        }
+
+        @GetMapping("/test/conflict")
+        void conflict() throws Exception {
+            throw new LinkCardinalityViolationException("Asset asset-1 already has an active link");
+        }
+
+        @GetMapping("/test/validation")
+        void validation() throws Exception {
+            throw new TransformSchemaValidationException("Payload invalid");
+        }
+
+        @GetMapping("/test/internal")
+        void internal() throws Exception {
+            throw new EventGenerationException("boom", new RuntimeException("boom"));
+        }
+    }
+}

--- a/src/test/java/com/db/assetstore/infra/service/AssetCommandServiceCommandLogDataTest.java
+++ b/src/test/java/com/db/assetstore/infra/service/AssetCommandServiceCommandLogDataTest.java
@@ -3,6 +3,7 @@ package com.db.assetstore.infra.service;
 import com.db.assetstore.AssetType;
 import com.db.assetstore.domain.model.type.AVDecimal;
 import com.db.assetstore.domain.model.type.AVString;
+import com.db.assetstore.domain.exception.command.CommandException;
 import com.db.assetstore.domain.service.cmd.AssetCommand;
 import com.db.assetstore.domain.service.cmd.AssetCommandVisitor;
 import com.db.assetstore.domain.service.cmd.CommandResult;
@@ -122,7 +123,7 @@ class AssetCommandServiceCommandLogDataTest {
     }
 
     @Test
-    void execute_whenCommandReportsFailure_doesNotPersistLog() {
+    void execute_whenCommandReportsFailure_doesNotPersistLog() throws Exception {
         FailingCommand command = new FailingCommand("asset-456", "auditor");
 
         CommandResult<Void> result = service.execute(command);
@@ -137,7 +138,7 @@ class AssetCommandServiceCommandLogDataTest {
     record FailingCommand(String assetId, String executedBy) implements AssetCommand<Void> {
 
         @Override
-        public CommandResult<Void> accept(AssetCommandVisitor visitor) {
+        public CommandResult<Void> accept(AssetCommandVisitor visitor) throws CommandException {
             return CommandResult.failure(assetId);
         }
     }

--- a/src/test/java/com/db/assetstore/infra/service/AssetLinkCommandDataTest.java
+++ b/src/test/java/com/db/assetstore/infra/service/AssetLinkCommandDataTest.java
@@ -1,5 +1,6 @@
 package com.db.assetstore.infra.service;
 
+import com.db.assetstore.domain.exception.link.LinkCardinalityViolationException;
 import com.db.assetstore.domain.model.link.LinkCardinality;
 import com.db.assetstore.domain.service.cmd.CommandResult;
 import com.db.assetstore.domain.service.link.cmd.CreateAssetLinkCommand;
@@ -77,7 +78,7 @@ class AssetLinkCommandDataTest {
     }
 
     @Test
-    void createLink_reactivatesExistingRowInsteadOfInserting() {
+    void createLink_reactivatesExistingRowInsteadOfInserting() throws Exception {
         linkDefinitionRepo.save(LinkDefinitionEntity.builder()
                 .entityType("WORKFLOW")
                 .entitySubtype("BULK")
@@ -122,7 +123,7 @@ class AssetLinkCommandDataTest {
     }
 
     @Test
-    void deleteLink_marksLinkInactive() {
+    void deleteLink_marksLinkInactive() throws Exception {
         linkDefinitionRepo.save(LinkDefinitionEntity.builder()
                 .entityType("WORKFLOW")
                 .entitySubtype("REVALUATION")
@@ -161,7 +162,7 @@ class AssetLinkCommandDataTest {
     }
 
     @Test
-    void createLink_respectsTargetSideCardinality() {
+    void createLink_respectsTargetSideCardinality() throws Exception {
         linkDefinitionRepo.save(LinkDefinitionEntity.builder()
                 .entityType("WORKFLOW")
                 .entitySubtype("MONITORING")
@@ -190,12 +191,12 @@ class AssetLinkCommandDataTest {
         assertThat(service.execute(first).success()).isTrue();
 
         assertThatThrownBy(() -> service.execute(second))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(LinkCardinalityViolationException.class)
                 .hasMessageContaining("Target WF-99 already linked");
     }
 
     @Test
-    void oneToMany_allowsMultipleLinksForAsset() {
+    void oneToMany_allowsMultipleLinksForAsset() throws Exception {
         linkDefinitionRepo.save(LinkDefinitionEntity.builder()
                 .entityType("WORKFLOW")
                 .entitySubtype("CHG")
@@ -230,7 +231,7 @@ class AssetLinkCommandDataTest {
     }
 
     @Test
-    void oneToOne_limitsBothSides() {
+    void oneToOne_limitsBothSides() throws Exception {
         linkDefinitionRepo.save(LinkDefinitionEntity.builder()
                 .entityType("WORKFLOW")
                 .entitySubtype("BULK")
@@ -259,7 +260,7 @@ class AssetLinkCommandDataTest {
                 .build();
 
         assertThatThrownBy(() -> service.execute(second))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(LinkCardinalityViolationException.class)
                 .hasMessageContaining("Asset asset-1 already has an active link for WORKFLOW/BULK");
 
         CreateAssetLinkCommand third = CreateAssetLinkCommand.builder()
@@ -272,12 +273,12 @@ class AssetLinkCommandDataTest {
                 .build();
 
         assertThatThrownBy(() -> service.execute(third))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(LinkCardinalityViolationException.class)
                 .hasMessageContaining("Target WF-1 already linked for WORKFLOW/BULK");
     }
 
     @Test
-    void manyToOne_limitsAssetSideOnly() {
+    void manyToOne_limitsAssetSideOnly() throws Exception {
         linkDefinitionRepo.save(LinkDefinitionEntity.builder()
                 .entityType("INSTRUMENT")
                 .entitySubtype("MONITORING")
@@ -306,7 +307,7 @@ class AssetLinkCommandDataTest {
                 .build();
 
         assertThatThrownBy(() -> service.execute(second))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(LinkCardinalityViolationException.class)
                 .hasMessageContaining("Asset asset-1 already has an active link for INSTRUMENT/MONITORING");
 
         CreateAssetLinkCommand third = CreateAssetLinkCommand.builder()

--- a/src/test/java/com/db/assetstore/infra/service/link/AssetLinkCommandValidatorTest.java
+++ b/src/test/java/com/db/assetstore/infra/service/link/AssetLinkCommandValidatorTest.java
@@ -1,0 +1,119 @@
+package com.db.assetstore.infra.service.link;
+
+import com.db.assetstore.domain.exception.link.InactiveLinkDefinitionException;
+import com.db.assetstore.domain.exception.link.LinkAlreadyExistsException;
+import com.db.assetstore.domain.exception.link.LinkCardinalityViolationException;
+import com.db.assetstore.domain.model.link.LinkCardinality;
+import com.db.assetstore.domain.service.link.cmd.CreateAssetLinkCommand;
+import com.db.assetstore.infra.jpa.AssetLinkEntity;
+import com.db.assetstore.infra.jpa.LinkDefinitionEntity;
+import com.db.assetstore.infra.repository.AssetLinkRepo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AssetLinkCommandValidatorTest {
+
+    AssetLinkRepo assetLinkRepo;
+    AssetLinkCommandValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        assetLinkRepo = mock(AssetLinkRepo.class);
+        validator = new AssetLinkCommandValidator(assetLinkRepo);
+    }
+
+    @Test
+    void validateCreate_whenDefinitionInactive_throwsInactiveException() {
+        LinkDefinitionEntity definition = LinkDefinitionEntity.builder()
+                .entityType("WORKFLOW")
+                .entitySubtype("BULK")
+                .cardinality(LinkCardinality.ASSET_ONE_TARGET_ONE)
+                .active(false)
+                .build();
+
+        CreateAssetLinkCommand command = sampleCommand();
+
+        assertThatThrownBy(() -> validator.validateCreate(command, definition))
+                .isInstanceOf(InactiveLinkDefinitionException.class)
+                .hasMessageContaining("inactive");
+    }
+
+    @Test
+    void validateCreate_whenDuplicateActiveLink_throwsLinkAlreadyExistsException() {
+        LinkDefinitionEntity definition = activeDefinition();
+        CreateAssetLinkCommand command = sampleCommand();
+
+        when(assetLinkRepo.activeLink(eq("asset-1"), eq("WORKFLOW"), eq("BULK"), eq("WF-42")))
+                .thenReturn(Optional.of(AssetLinkEntity.builder().id(1L).build()));
+
+        assertThatThrownBy(() -> validator.validateCreate(command, definition))
+                .isInstanceOf(LinkAlreadyExistsException.class)
+                .hasMessageContaining("Active link already exists");
+    }
+
+    @Test
+    void validateCreate_whenAssetSideLimited_throwsCardinalityViolation() {
+        LinkDefinitionEntity definition = activeDefinition().toBuilder()
+                .cardinality(LinkCardinality.ASSET_ONE_TARGET_MANY)
+                .build();
+        CreateAssetLinkCommand command = sampleCommand();
+
+        when(assetLinkRepo.activeLink(any(), any(), any(), any())).thenReturn(Optional.empty());
+        when(assetLinkRepo.activeForAssetType("asset-1", "WORKFLOW", "BULK"))
+                .thenReturn(List.of(AssetLinkEntity.builder().id(1L).build()));
+        when(assetLinkRepo.activeForTarget("WORKFLOW", "BULK", "WF-42"))
+                .thenReturn(List.of());
+
+        assertThatThrownBy(() -> validator.validateCreate(command, definition))
+                .isInstanceOf(LinkCardinalityViolationException.class)
+                .hasMessageContaining("Asset asset-1 already has an active link");
+    }
+
+    @Test
+    void validateCreate_whenTargetSideLimited_throwsCardinalityViolation() {
+        LinkDefinitionEntity definition = activeDefinition().toBuilder()
+                .cardinality(LinkCardinality.ASSET_MANY_TARGET_ONE)
+                .build();
+        CreateAssetLinkCommand command = sampleCommand();
+
+        when(assetLinkRepo.activeLink(any(), any(), any(), any())).thenReturn(Optional.empty());
+        when(assetLinkRepo.activeForAssetType("asset-1", "WORKFLOW", "BULK"))
+                .thenReturn(List.of());
+        when(assetLinkRepo.activeForTarget("WORKFLOW", "BULK", "WF-42"))
+                .thenReturn(List.of(AssetLinkEntity.builder().id(2L).build()));
+
+        assertThatThrownBy(() -> validator.validateCreate(command, definition))
+                .isInstanceOf(LinkCardinalityViolationException.class)
+                .hasMessageContaining("Target WF-42 already linked");
+    }
+
+    private static CreateAssetLinkCommand sampleCommand() {
+        return CreateAssetLinkCommand.builder()
+                .assetId("asset-1")
+                .entityType("WORKFLOW")
+                .entitySubtype("BULK")
+                .targetCode("WF-42")
+                .executedBy("tester")
+                .requestTime(Instant.parse("2024-01-01T00:00:00Z"))
+                .build();
+    }
+
+    private static LinkDefinitionEntity activeDefinition() {
+        return LinkDefinitionEntity.builder()
+                .entityType("WORKFLOW")
+                .entitySubtype("BULK")
+                .cardinality(LinkCardinality.ASSET_ONE_TARGET_ONE)
+                .active(true)
+                .build();
+    }
+}

--- a/src/test/java/integration/AssetBulkE2ETest.java
+++ b/src/test/java/integration/AssetBulkE2ETest.java
@@ -30,7 +30,7 @@ class AssetBulkE2ETest {
         mockMvc.perform(post("/assets/bulk")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(payload))
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$", hasSize(2)))
                 .andExpect(jsonPath("$[0]", is("cre-1")))

--- a/src/test/java/integration/AssetCommonUpdateE2ETest.java
+++ b/src/test/java/integration/AssetCommonUpdateE2ETest.java
@@ -38,7 +38,7 @@ class AssetCommonUpdateE2ETest {
         MvcResult res = mockMvc.perform(post("/assets")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(payload))
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andReturn();
         String id = res.getResponse().getContentAsString();
 

--- a/src/test/java/integration/IntegrationAssetHistoryTest.java
+++ b/src/test/java/integration/IntegrationAssetHistoryTest.java
@@ -37,7 +37,7 @@ class IntegrationAssetHistoryTest {
     AssetHistoryService historyService;
 
     @Test
-    void multipleUpdatesProduceHistoryAndFinalState() {
+    void multipleUpdatesProduceHistoryAndFinalState() throws Exception {
         CreateAssetCommand createCmd = CreateAssetCommand.builder()
                 .id("cre-int-hist")
                 .type(AssetType.CRE)

--- a/src/test/java/integration/IntegrationMultipleAssetTypesTest.java
+++ b/src/test/java/integration/IntegrationMultipleAssetTypesTest.java
@@ -29,7 +29,7 @@ class IntegrationMultipleAssetTypesTest {
     AssetQueryService queryService;
 
     @Test
-    void persistTwoDifferentAssetTypes_CRE_and_SHIP() {
+    void persistTwoDifferentAssetTypes_CRE_and_SHIP() throws Exception {
         var creCmd = CreateAssetCommand.builder()
                 .id("cre-int-2")
                 .type(AssetType.CRE)


### PR DESCRIPTION
## Summary
- remove the DomainErrorType categorisation and collapse domain exceptions onto classic checked hierarchies
- enrich asset canonicalisation, event generation, and transform failures with contextual details like asset ids and transform names
- centralise HTTP mappings on concrete exception classes in GlobalExceptionHandler and update unit tests to assert the new messaging

## Testing
- mvn -q -DskipTests=false test *(fails: unable to resolve Spring Boot parent POM because the Maven Central repository is unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d525aea5f083308033a88e8b9f7daf