### PR TITLE
Ensure brace usage and streamline attribute helpers

### DIFF
--- a/src/main/java/com/db/assetstore/domain/json/AssetCanonicalizer.java
+++ b/src/main/java/com/db/assetstore/domain/json/AssetCanonicalizer.java
@@ -57,14 +57,24 @@ public final class AssetCanonicalizer {
     }
 
     private static void put(ObjectNode node, String field, Object value) {
-        if (value == null) return;
-        if (value instanceof String s) node.put(field, s);
-        else if (value instanceof Integer i) node.put(field, i);
-        else if (value instanceof Long l) node.put(field, l);
-        else if (value instanceof BigDecimal bd) node.put(field, bd);
-        else if (value instanceof Boolean b) node.put(field, b);
-        else if (value instanceof Number n) node.put(field, n.doubleValue());
-        else node.put(field, value.toString());
+        if (value == null) {
+            return;
+        }
+        if (value instanceof String s) {
+            node.put(field, s);
+        } else if (value instanceof Integer i) {
+            node.put(field, i);
+        } else if (value instanceof Long l) {
+            node.put(field, l);
+        } else if (value instanceof BigDecimal bd) {
+            node.put(field, bd);
+        } else if (value instanceof Boolean b) {
+            node.put(field, b);
+        } else if (value instanceof Number n) {
+            node.put(field, n.doubleValue());
+        } else {
+            node.put(field, value.toString());
+        }
     }
 
     private static final class AttributeNodeWriter implements AttributeValueVisitor<Void> {
@@ -85,20 +95,29 @@ public final class AssetCanonicalizer {
         }
 
         @Override public Void visitString(String value, String ignored) {
-            if (value == null) target.putNull(field);
-            else target.put(field, value);
+            if (value == null) {
+                target.putNull(field);
+            } else {
+                target.put(field, value);
+            }
             return null;
         }
 
         @Override public Void visitDecimal(BigDecimal value, String ignored) {
-            if (value == null) target.putNull(field);
-            else target.put(field, value);
+            if (value == null) {
+                target.putNull(field);
+            } else {
+                target.put(field, value);
+            }
             return null;
         }
 
         @Override public Void visitBoolean(Boolean value, String ignored) {
-            if (value == null) target.putNull(field);
-            else target.put(field, value);
+            if (value == null) {
+                target.putNull(field);
+            } else {
+                target.put(field, value);
+            }
             return null;
         }
     }

--- a/src/main/java/com/db/assetstore/domain/json/AttributeJsonReader.java
+++ b/src/main/java/com/db/assetstore/domain/json/AttributeJsonReader.java
@@ -25,15 +25,21 @@ public final class AttributeJsonReader {
     private final AttributeDefinitionRegistry attributeDefinitionRegistry;
 
     public List<AttributeValue<?>> read(AssetType type, JsonNode obj) {
-        if (type == null || obj == null || !obj.isObject()) return List.of();
+        if (type == null || obj == null || !obj.isObject()) {
+            return List.of();
+        }
 
         var defs = attributeDefinitionRegistry.getDefinitions(type);
-        if (defs == null || defs.isEmpty()) return List.of();
+        if (defs == null || defs.isEmpty()) {
+            return List.of();
+        }
 
         var converted = new ArrayList<AttributeValue<?>>();
         for (var e : defs.entrySet()) {
             String name = e.getKey();
-            if (!obj.has(name)) continue;
+            if (!obj.has(name)) {
+                continue;
+            }
 
             JsonNode node = obj.get(name);
             ValueType vt = e.getValue().valueType();
@@ -49,7 +55,9 @@ public final class AttributeJsonReader {
     }
 
     private Object convert(JsonNode node, ValueType vt) {
-        if (node == null || node.isNull()) return null;
+        if (node == null || node.isNull()) {
+            return null;
+        }
         try {
             return switch (vt == null ? ValueType.STRING : vt) {
                 case STRING  -> mapper.convertValue(node, String.class);

--- a/src/main/java/com/db/assetstore/domain/model/Asset.java
+++ b/src/main/java/com/db/assetstore/domain/model/Asset.java
@@ -54,7 +54,9 @@ public final class Asset {
     @JsonProperty("attributes")
     public Map<String, AttributeValue<?>> getAttributesJson() {
         Map<String, AttributeValue<?>> out = new LinkedHashMap<>();
-        if (attributes == null || attributes.isEmpty()) return out;
+        if (attributes == null || attributes.isEmpty()) {
+            return out;
+        }
         attributes.asMapView().forEach((name, list) -> {
             if (list != null && !list.isEmpty()) {
                 out.put(name, list.get(0));
@@ -80,7 +82,9 @@ public final class Asset {
      * Append a single attribute value to the collection (non-destructive for other attributes).
      */
     public Asset setAttribute(AttributeValue<?> av) {
-        if (av == null) return this;
+        if (av == null) {
+            return this;
+        }
         this.attributes = this.attributes.add(av);
         return this;
     }

--- a/src/main/java/com/db/assetstore/domain/model/attribute/AttributesCollection.java
+++ b/src/main/java/com/db/assetstore/domain/model/attribute/AttributesCollection.java
@@ -7,10 +7,16 @@ import com.db.assetstore.domain.model.type.AttributeType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 public final class AttributesCollection {
@@ -22,20 +28,28 @@ public final class AttributesCollection {
     }
 
     public static AttributesCollection fromFlat(Collection<AttributeValue<?>> flat) {
-        if (flat == null || flat.isEmpty()) return empty();
+        if (flat == null || flat.isEmpty()) {
+            return empty();
+        }
         LinkedHashMap<String, List<AttributeValue<?>>> map = new LinkedHashMap<>();
         for (AttributeValue<?> av : flat) {
-            if (av == null) continue;
+            if (av == null) {
+                continue;
+            }
             map.computeIfAbsent(av.name(), k -> new ArrayList<>()).add(av);
         }
         return new AttributesCollection(map);
     }
 
     public static AttributesCollection fromMap(Map<String, List<AttributeValue<?>>> map) {
-        if (map == null || map.isEmpty()) return empty();
+        if (map == null || map.isEmpty()) {
+            return empty();
+        }
         LinkedHashMap<String, List<AttributeValue<?>>> copy = new LinkedHashMap<>();
         map.forEach((k, v) -> {
-            if (k == null || v == null || v.isEmpty()) return;
+            if (k == null || v == null || v.isEmpty()) {
+                return;
+            }
             copy.put(k, new ArrayList<>(v));
         });
         return new AttributesCollection(copy);
@@ -82,11 +96,15 @@ public final class AttributesCollection {
 
     public <T> List<T> getMany(String name, Class<T> type) {
         var vs = data.get(name);
-        if (vs == null || vs.isEmpty()) return List.of();
+        if (vs == null || vs.isEmpty()) {
+            return List.of();
+        }
         ArrayList<T> out = new ArrayList<>(vs.size());
         for (var av : vs) {
             Object v = av.value();
-            if (v != null) out.add(type.cast(v));
+            if (v != null) {
+                out.add(type.cast(v));
+            }
         }
         return Collections.unmodifiableList(out);
     }
@@ -123,7 +141,9 @@ public final class AttributesCollection {
     }
 
     private AttributesCollection append(AttributeValue<?> av) {
-        if (av == null) return this;
+        if (av == null) {
+            return this;
+        }
         LinkedHashMap<String, List<AttributeValue<?>>> copy = copyData();
         copy.computeIfAbsent(av.name(), k -> new ArrayList<>()).add(av);
         return new AttributesCollection(copy);

--- a/src/main/java/com/db/assetstore/domain/service/startup/AttributeBootstrapService.java
+++ b/src/main/java/com/db/assetstore/domain/service/startup/AttributeBootstrapService.java
@@ -1,16 +1,15 @@
 package com.db.assetstore.domain.service.startup;
 
 import com.db.assetstore.AssetType;
-import com.db.assetstore.domain.model.type.AttributeType;
-import com.db.assetstore.infra.jpa.AttributeDefEntity;
 import com.db.assetstore.domain.service.type.AttributeDefinitionRegistry;
+import com.db.assetstore.domain.service.type.TypeSchemaRegistry;
+import com.db.assetstore.infra.jpa.AttributeDefEntity;
 import com.db.assetstore.infra.repository.AttributeDefRepository;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import com.db.assetstore.domain.service.type.TypeSchemaRegistry;
 
 
 @Service
@@ -35,7 +34,7 @@ public class AttributeBootstrapService {
                     var e = new AttributeDefEntity(
                             t,
                             def.name(),
-                            toAttrType(def.valueType()),
+                            AttributeDefinitionRegistry.toAttributeType(def.valueType()),
                             def.required()
                     );
                     repository.save(e);
@@ -43,15 +42,6 @@ public class AttributeBootstrapService {
                 log.info("Bootstrapped attribute from schemas {type={}, count={}}", t, defs.size());
             }
         }
-    }
-
-    private static AttributeType toAttrType(AttributeDefinitionRegistry.ValueType vt) {
-        if (vt == null) return AttributeType.STRING;
-        return switch (vt) {
-            case STRING -> AttributeType.STRING;
-            case DECIMAL -> AttributeType.DECIMAL;
-            case BOOLEAN -> AttributeType.BOOLEAN;
-        };
     }
 }
 

--- a/src/main/java/com/db/assetstore/domain/service/type/AttributeDefinitionRegistry.java
+++ b/src/main/java/com/db/assetstore/domain/service/type/AttributeDefinitionRegistry.java
@@ -1,15 +1,20 @@
 package com.db.assetstore.domain.service.type;
 
 import com.db.assetstore.AssetType;
+import com.db.assetstore.domain.model.type.AttributeType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.io.InputStream;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
@@ -115,5 +120,16 @@ public final class AttributeDefinitionRegistry {
 
     public record Def(String name, ValueType valueType, boolean required) {
         public boolean required() { return required; }
+    }
+
+    public static AttributeType toAttributeType(ValueType valueType) {
+        if (valueType == null) {
+            return AttributeType.STRING;
+        }
+        return switch (valueType) {
+            case STRING -> AttributeType.STRING;
+            case DECIMAL -> AttributeType.DECIMAL;
+            case BOOLEAN -> AttributeType.BOOLEAN;
+        };
     }
 }

--- a/src/main/java/com/db/assetstore/domain/service/type/AttributeDefinitionsProvider.java
+++ b/src/main/java/com/db/assetstore/domain/service/type/AttributeDefinitionsProvider.java
@@ -1,13 +1,15 @@
 package com.db.assetstore.domain.service.type;
 
 import com.db.assetstore.AssetType;
-import com.db.assetstore.domain.model.type.AttributeType;
 import com.db.assetstore.infra.jpa.AttributeDefEntity;
 import com.db.assetstore.infra.repository.AttributeDefRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -17,7 +19,9 @@ public class AttributeDefinitionsProvider {
     private final TypeSchemaRegistry typeSchemaRegistry;
 
     public Map<String, AttributeDefEntity> resolve(AssetType type) {
-        if (type == null) return Collections.emptyMap();
+        if (type == null) {
+            return Collections.emptyMap();
+        }
 
         boolean hasSchema = typeSchemaRegistry.getSchemaPath(type).isPresent();
         if (hasSchema) {
@@ -27,23 +31,16 @@ public class AttributeDefinitionsProvider {
             for (var entry : regDefs.entrySet()) {
                 var d = entry.getValue();
                 tmp.put(entry.getKey(),
-                        new AttributeDefEntity(type, d.name(), toAttrType(d.valueType()), d.required()));
+                        new AttributeDefEntity(type, d.name(),
+                                AttributeDefinitionRegistry.toAttributeType(d.valueType()), d.required()));
             }
             return tmp;
         }
         List<AttributeDefEntity> defs = defRepo.findAllByType(type);
         Map<String, AttributeDefEntity> map = new HashMap<>();
-        for (AttributeDefEntity d : defs) map.put(d.getName(), d);
+        for (AttributeDefEntity d : defs) {
+            map.put(d.getName(), d);
+        }
         return map;
-    }
-
-    private static AttributeType toAttrType(
-            AttributeDefinitionRegistry.ValueType vt) {
-        if (vt == null) return AttributeType.STRING;
-        return switch (vt) {
-            case STRING -> AttributeType.STRING;
-            case DECIMAL -> AttributeType.DECIMAL;
-            case BOOLEAN -> AttributeType.BOOLEAN;
-        };
     }
 }

--- a/src/main/java/com/db/assetstore/domain/service/validation/AssetTypeValidator.java
+++ b/src/main/java/com/db/assetstore/domain/service/validation/AssetTypeValidator.java
@@ -7,7 +7,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -31,7 +35,9 @@ public final class AssetTypeValidator {
         String schemaPath = registry.getSchemaPath(type).orElse(null);
         Map<String, Object> map = new LinkedHashMap<>();
         for (AttributeValue<?> av : attrs) {
-            if (av == null) continue;
+            if (av == null) {
+                continue;
+            }
             map.put(av.name(), av.value());
         }
         try {

--- a/src/main/java/com/db/assetstore/domain/service/validation/JsonSchemaValidator.java
+++ b/src/main/java/com/db/assetstore/domain/service/validation/JsonSchemaValidator.java
@@ -2,7 +2,11 @@ package com.db.assetstore.domain.service.validation;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.networknt.schema.*;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SchemaValidatorsConfig;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -24,12 +28,16 @@ public final class JsonSchemaValidator {
 
     public List<String> validate(JsonNode payload, JsonSchema compiled) {
         Set<ValidationMessage> v = compiled.validate(payload);
-        if (v == null || v.isEmpty()) return Collections.emptyList();
+        if (v == null || v.isEmpty()) {
+            return Collections.emptyList();
+        }
         return v.stream().map(ValidationMessage::getMessage).sorted().toList();
     }
 
     public void validateOrThrow(String json, String schemaRes) {
-        if (isBlank(schemaRes)) return;
+        if (isBlank(schemaRes)) {
+            return;
+        }
         log.info("Validating JSON against schema: {}", schemaRes);
         JsonNode payload = parse(json);
         JsonSchema compiled = compileSchema(schemaRes);
@@ -63,7 +71,9 @@ public final class JsonSchemaValidator {
     }
 
     private JsonNode parse(String json) {
-        if (isBlank(json)) throw new IllegalArgumentException("Payload JSON is null/blank");
+        if (isBlank(json)) {
+            throw new IllegalArgumentException("Payload JSON is null/blank");
+        }
         try {
             return mapper.readTree(json.getBytes(StandardCharsets.UTF_8));
         } catch (Exception e) {

--- a/src/main/java/com/db/assetstore/infra/jpa/search/AttributePredicateVisitor.java
+++ b/src/main/java/com/db/assetstore/infra/jpa/search/AttributePredicateVisitor.java
@@ -61,7 +61,9 @@ public final class AttributePredicateVisitor {
     }
 
     private static String ensureLikePattern(String s) {
-        if (s == null) return null;
+        if (s == null) {
+            return null;
+        }
         String norm = s.toLowerCase();
         return (norm.indexOf('%') >= 0 || norm.indexOf('_') >= 0) ? norm : "%" + norm + "%";
     }

--- a/src/main/java/com/db/assetstore/infra/mapper/AttributeHistoryMapper.java
+++ b/src/main/java/com/db/assetstore/infra/mapper/AttributeHistoryMapper.java
@@ -12,7 +12,9 @@ import org.mapstruct.Mappings;
 public interface AttributeHistoryMapper {
 
     default AttributeHistory toModel(AttributeHistoryEntity e) {
-        if (e == null) return null;
+        if (e == null) {
+            return null;
+        }
         String assetId = e.getAsset() != null ? e.getAsset().getId() : null;
         return new AttributeHistory(
                 assetId,

--- a/src/main/java/com/db/assetstore/infra/service/AssetService.java
+++ b/src/main/java/com/db/assetstore/infra/service/AssetService.java
@@ -112,12 +112,24 @@ public class AssetService {
         AssetEntity entity = assetRepo.findByIdAndDeleted(id, 0)
                 .orElseThrow(() -> new IllegalArgumentException("Asset not found: " + id));
 
-        if (patch.status() != null) entity.setStatus(patch.status());
-        if (patch.subtype() != null) entity.setSubtype(patch.subtype());
-        if (patch.notionalAmount() != null) entity.setNotionalAmount(patch.notionalAmount());
-        if (patch.year() != null) entity.setYear(patch.year());
-        if (patch.description() != null) entity.setDescription(patch.description());
-        if (patch.currency() != null) entity.setCurrency(patch.currency());
+        if (patch.status() != null) {
+            entity.setStatus(patch.status());
+        }
+        if (patch.subtype() != null) {
+            entity.setSubtype(patch.subtype());
+        }
+        if (patch.notionalAmount() != null) {
+            entity.setNotionalAmount(patch.notionalAmount());
+        }
+        if (patch.year() != null) {
+            entity.setYear(patch.year());
+        }
+        if (patch.description() != null) {
+            entity.setDescription(patch.description());
+        }
+        if (patch.currency() != null) {
+            entity.setCurrency(patch.currency());
+        }
         entity.setModifiedBy(executedBy);
         entity.setModifiedAt(Instant.now());
         entity = assetRepo.save(entity);

--- a/src/main/java/com/db/assetstore/infra/service/AttributeComparator.java
+++ b/src/main/java/com/db/assetstore/infra/service/AttributeComparator.java
@@ -12,26 +12,36 @@ public final class AttributeComparator {
 
     // Comparator must not modify data. Operates on domain AttributeValue and uses visitor for type-dispatch.
     public static boolean checkforUpdates(AttributeValue<?> existing, AttributeValue<?> incoming) {
-        if (existing == null || incoming == null) return existing != incoming;
+        if (existing == null || incoming == null) {
+            return existing != incoming;
+        }
         return incoming.accept(new AttributeValueVisitor<>() {
             @Override
             public Boolean visitString(String v, String name) {
-                if (existing.attributeType() != AttributeType.STRING) return true;
+                if (existing.attributeType() != AttributeType.STRING) {
+                    return true;
+                }
                 String a = (String) existing.value();
                 return !Objects.equals(a, v);
             }
 
             @Override
             public Boolean visitDecimal(BigDecimal v, String name) {
-                if (existing.attributeType() != AttributeType.DECIMAL) return true;
+                if (existing.attributeType() != AttributeType.DECIMAL) {
+                    return true;
+                }
                 BigDecimal a = (BigDecimal) existing.value();
-                if (a == null || v == null) return a != v;
+                if (a == null || v == null) {
+                    return a != v;
+                }
                 return a.compareTo(v) != 0;
             }
 
             @Override
             public Boolean visitBoolean(Boolean v, String name) {
-                if (existing.attributeType() != AttributeType.BOOLEAN) return true;
+                if (existing.attributeType() != AttributeType.BOOLEAN) {
+                    return true;
+                }
                 Boolean a = (Boolean) existing.value();
                 return !Objects.equals(a, v);
             }

--- a/src/main/java/com/db/assetstore/infra/service/AttributeUpdater.java
+++ b/src/main/java/com/db/assetstore/infra/service/AttributeUpdater.java
@@ -12,7 +12,7 @@ public final class AttributeUpdater {
     private AttributeUpdater() {}
 
     public static void apply(AttributeEntity e, AttributeValue<?> av) {
-        if (e == null || av == null){
+        if (e == null || av == null) {
             return;
         }
         e.addHistory(Instant.now());


### PR DESCRIPTION
## Summary
- enforce block braces across conditional branches in services, validators, and JSON helpers to satisfy PMD style guidance
- replace wildcard imports, remove unused imports, and order remaining imports alphabetically
- centralize the ValueType-to-AttributeType conversion in AttributeDefinitionRegistry to eliminate duplication in bootstrap and provider services

## Testing
- `mvn -q test` *(fails: dependency download blocked by offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a7e78b8c8330bbbaa1596d04c056