### PR TITLE
Replace Objects.requireNonNull with Lombok NonNull

### DIFF
--- a/src/main/java/com/db/assetstore/domain/model/attribute/AttributesCollection.java
+++ b/src/main/java/com/db/assetstore/domain/model/attribute/AttributesCollection.java
@@ -6,6 +6,7 @@ import com.db.assetstore.domain.model.type.AVString;
 import com.db.assetstore.domain.model.type.AttributeType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 import java.math.BigDecimal;
@@ -15,7 +16,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -126,8 +126,8 @@ public final class AttributesCollection {
     }
     public AttributesCollection add(AttributeValue<?> av)       { return append(av); }
 
-    public AttributesCollection clear(String name, AttributeType type) {
-        return switch (Objects.requireNonNull(type)) {
+    public AttributesCollection clear(String name, @NonNull AttributeType type) {
+        return switch (type) {
             case STRING  -> set(name, (String) null);
             case DECIMAL -> set(name, (BigDecimal) null);
             case BOOLEAN -> set(name, (Boolean) null);
@@ -155,5 +155,5 @@ public final class AttributesCollection {
         return copy;
     }
 
-    private static String req(String n) { return Objects.requireNonNull(n, "name"); }
+    private static String req(@NonNull String n) { return n; }
 }

--- a/src/main/java/com/db/assetstore/domain/search/Condition.java
+++ b/src/main/java/com/db/assetstore/domain/search/Condition.java
@@ -1,17 +1,16 @@
 package com.db.assetstore.domain.search;
 
 import com.db.assetstore.domain.model.attribute.AttributeValue;
-
-import java.util.Objects;
+import lombok.NonNull;
 
 public final class Condition<T> {
     private final String attribute;
     private final Operator operator;
     private final AttributeValue<T> value;
 
-    public Condition(String attribute, Operator operator, AttributeValue<T> value) {
-        this.attribute = Objects.requireNonNull(attribute);
-        this.operator = Objects.requireNonNull(operator);
+    public Condition(@NonNull String attribute, @NonNull Operator operator, AttributeValue<T> value) {
+        this.attribute = attribute;
+        this.operator = operator;
         this.value = value;
     }
 

--- a/src/main/java/com/db/assetstore/domain/service/EventService.java
+++ b/src/main/java/com/db/assetstore/domain/service/EventService.java
@@ -6,13 +6,13 @@ import com.db.assetstore.domain.service.transform.JsonTransformer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
-import java.util.Objects;
 
 /**
  * Service that generates event JSON from an Asset using JSLT templates.
@@ -33,9 +33,7 @@ public final class EventService {
     private final AssetCanonicalizer canonicalizer;
     private final ObjectMapper objectMapper;
 
-    public String generate(String eventName, Asset asset) throws JsonProcessingException {
-        Objects.requireNonNull(eventName, "eventName");
-        Objects.requireNonNull(asset, "asset");
+    public String generate(@NonNull String eventName, @NonNull Asset asset) throws JsonProcessingException {
         log.debug("Generating event '{}' for asset id={} type={}", eventName, asset.getId(), asset.getType());
         String canonical = canonicalizer.toCanonicalJson(asset);
 

--- a/src/main/java/com/db/assetstore/domain/service/cmd/AssetCommand.java
+++ b/src/main/java/com/db/assetstore/domain/service/cmd/AssetCommand.java
@@ -1,6 +1,6 @@
 package com.db.assetstore.domain.service.cmd;
 
-import java.util.Objects;
+import lombok.NonNull;
 
 /**
  * Marker interface for commands executed by the {@link com.db.assetstore.domain.service.AssetCommandService}.
@@ -29,7 +29,7 @@ public interface AssetCommand<R> {
     /**
      * Utility method for implementors to guard against null visitors.
      */
-    default AssetCommandVisitor requireVisitor(AssetCommandVisitor visitor) {
-        return Objects.requireNonNull(visitor, "visitor");
+    default AssetCommandVisitor requireVisitor(@NonNull AssetCommandVisitor visitor) {
+        return visitor;
     }
 }

--- a/src/main/java/com/db/assetstore/domain/service/cmd/CommandResult.java
+++ b/src/main/java/com/db/assetstore/domain/service/cmd/CommandResult.java
@@ -1,17 +1,13 @@
 package com.db.assetstore.domain.service.cmd;
 
-import java.util.Objects;
+import lombok.NonNull;
 
 /**
  * Encapsulates the outcome of executing a command together with the asset identifier used for logging.
  *
  * @param <T> result type produced by the command execution
  */
-public record CommandResult<T>(T result, String assetId, boolean success) {
-
-    public CommandResult {
-        Objects.requireNonNull(assetId, "assetId");
-    }
+public record CommandResult<T>(T result, @NonNull String assetId, boolean success) {
 
     public CommandResult(T result, String assetId) {
         this(result, assetId, true);

--- a/src/main/java/com/db/assetstore/domain/service/cmd/DeleteAssetCommand.java
+++ b/src/main/java/com/db/assetstore/domain/service/cmd/DeleteAssetCommand.java
@@ -1,6 +1,7 @@
 package com.db.assetstore.domain.service.cmd;
 
 import lombok.Builder;
+import lombok.NonNull;
 
 import java.time.Instant;
 
@@ -9,7 +10,7 @@ import java.time.Instant;
  */
 @Builder
 public record DeleteAssetCommand(
-        String assetId,
+        @NonNull String assetId,
         String executedBy,
         Instant requestTime
 ) implements AssetCommand<Void> {

--- a/src/main/java/com/db/assetstore/domain/service/cmd/PatchAssetCommand.java
+++ b/src/main/java/com/db/assetstore/domain/service/cmd/PatchAssetCommand.java
@@ -2,6 +2,7 @@ package com.db.assetstore.domain.service.cmd;
 
 import com.db.assetstore.domain.model.attribute.AttributeValue;
 import lombok.Builder;
+import lombok.NonNull;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -12,7 +13,7 @@ import java.util.List;
  */
 @Builder
 public record PatchAssetCommand(
-        String assetId,
+        @NonNull String assetId,
         String status,
         String subtype,
         BigDecimal notionalAmount,

--- a/src/main/java/com/db/assetstore/domain/service/cmd/factory/AssetCommandFactoryRegistry.java
+++ b/src/main/java/com/db/assetstore/domain/service/cmd/factory/AssetCommandFactoryRegistry.java
@@ -7,9 +7,9 @@ import com.db.assetstore.domain.service.cmd.PatchAssetCommand;
 import com.db.assetstore.infra.api.dto.AssetCreateRequest;
 import com.db.assetstore.infra.api.dto.AssetDeleteRequest;
 import com.db.assetstore.infra.api.dto.AssetPatchRequest;
+import lombok.NonNull;
 import org.springframework.stereotype.Component;
 
-import java.util.Objects;
 
 @Component
 public class AssetCommandFactoryRegistry {
@@ -18,12 +18,12 @@ public class AssetCommandFactoryRegistry {
     private final PatchAssetCommandFactory patchFactory;
     private final DeleteAssetCommandFactory deleteFactory;
 
-    public AssetCommandFactoryRegistry(CreateAssetCommandFactory createFactory,
-                                       PatchAssetCommandFactory patchFactory,
-                                       DeleteAssetCommandFactory deleteFactory) {
-        this.createFactory = Objects.requireNonNull(createFactory, "createFactory");
-        this.patchFactory = Objects.requireNonNull(patchFactory, "patchFactory");
-        this.deleteFactory = Objects.requireNonNull(deleteFactory, "deleteFactory");
+    public AssetCommandFactoryRegistry(@NonNull CreateAssetCommandFactory createFactory,
+                                       @NonNull PatchAssetCommandFactory patchFactory,
+                                       @NonNull DeleteAssetCommandFactory deleteFactory) {
+        this.createFactory = createFactory;
+        this.patchFactory = patchFactory;
+        this.deleteFactory = deleteFactory;
     }
 
     public CreateAssetCommand createCreateCommand(AssetCreateRequest request) {
@@ -34,8 +34,7 @@ public class AssetCommandFactoryRegistry {
         return patchFactory.createCommand(type, id, request);
     }
 
-    public PatchAssetCommand createPatchCommand(AssetType type, AssetPatchRequest request) {
-        Objects.requireNonNull(request, "request");
+    public PatchAssetCommand createPatchCommand(AssetType type, @NonNull AssetPatchRequest request) {
         String id = request.getId();
         if (id == null || id.isBlank()) {
             throw new IllegalArgumentException("Patch request must contain an asset id");

--- a/src/main/java/com/db/assetstore/domain/service/cmd/factory/CreateAssetCommandFactory.java
+++ b/src/main/java/com/db/assetstore/domain/service/cmd/factory/CreateAssetCommandFactory.java
@@ -4,24 +4,22 @@ import com.db.assetstore.domain.json.AttributeJsonReader;
 import com.db.assetstore.domain.model.attribute.AttributeValue;
 import com.db.assetstore.domain.service.cmd.CreateAssetCommand;
 import com.db.assetstore.infra.api.dto.AssetCreateRequest;
+import lombok.NonNull;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
 import java.util.List;
-import java.util.Objects;
 
 @Component
 public class CreateAssetCommandFactory {
 
     private final AttributeJsonReader attributeJsonReader;
 
-    public CreateAssetCommandFactory(AttributeJsonReader attributeJsonReader) {
-        this.attributeJsonReader = Objects.requireNonNull(attributeJsonReader, "attributeJsonReader");
+    public CreateAssetCommandFactory(@NonNull AttributeJsonReader attributeJsonReader) {
+        this.attributeJsonReader = attributeJsonReader;
     }
 
-    public CreateAssetCommand createCommand(AssetCreateRequest request) {
-        Objects.requireNonNull(request, "request");
-
+    public CreateAssetCommand createCommand(@NonNull AssetCreateRequest request) {
         List<AttributeValue<?>> attributes = request.attributes() == null
                 ? List.of()
                 : List.copyOf(attributeJsonReader.read(request.type(), request.attributes()));

--- a/src/main/java/com/db/assetstore/domain/service/cmd/factory/DeleteAssetCommandFactory.java
+++ b/src/main/java/com/db/assetstore/domain/service/cmd/factory/DeleteAssetCommandFactory.java
@@ -2,20 +2,18 @@ package com.db.assetstore.domain.service.cmd.factory;
 
 import com.db.assetstore.domain.service.cmd.DeleteAssetCommand;
 import com.db.assetstore.infra.api.dto.AssetDeleteRequest;
+import lombok.NonNull;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
-import java.util.Objects;
 
 @Component
 public class DeleteAssetCommandFactory {
 
-    public DeleteAssetCommand createCommand(String assetId, AssetDeleteRequest request) {
-        Objects.requireNonNull(assetId, "assetId");
+    public DeleteAssetCommand createCommand(@NonNull String assetId, @NonNull AssetDeleteRequest request) {
         if (assetId.isBlank()) {
             throw new IllegalArgumentException("assetId must not be blank");
         }
-        Objects.requireNonNull(request, "request");
         if (request.id() == null || request.id().isBlank()) {
             throw new IllegalArgumentException("Delete request must include an asset id");
         }

--- a/src/main/java/com/db/assetstore/domain/service/cmd/factory/PatchAssetCommandFactory.java
+++ b/src/main/java/com/db/assetstore/domain/service/cmd/factory/PatchAssetCommandFactory.java
@@ -5,26 +5,23 @@ import com.db.assetstore.domain.json.AttributeJsonReader;
 import com.db.assetstore.domain.model.attribute.AttributeValue;
 import com.db.assetstore.domain.service.cmd.PatchAssetCommand;
 import com.db.assetstore.infra.api.dto.AssetPatchRequest;
+import lombok.NonNull;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
 import java.util.List;
-import java.util.Objects;
 
 @Component
 public class PatchAssetCommandFactory {
 
     private final AttributeJsonReader attributeJsonReader;
 
-    public PatchAssetCommandFactory(AttributeJsonReader attributeJsonReader) {
-        this.attributeJsonReader = Objects.requireNonNull(attributeJsonReader, "attributeJsonReader");
+    public PatchAssetCommandFactory(@NonNull AttributeJsonReader attributeJsonReader) {
+        this.attributeJsonReader = attributeJsonReader;
     }
 
-    public PatchAssetCommand createCommand(AssetType assetType, String assetId, AssetPatchRequest request) {
-        Objects.requireNonNull(assetType, "assetType");
-        Objects.requireNonNull(assetId, "assetId");
-        Objects.requireNonNull(request, "request");
-
+    public PatchAssetCommand createCommand(@NonNull AssetType assetType, @NonNull String assetId,
+                                           @NonNull AssetPatchRequest request) {
         if (assetId.isBlank()) {
             throw new IllegalArgumentException("assetId must not be blank");
         }

--- a/src/main/java/com/db/assetstore/domain/service/transform/JsonTransformer.java
+++ b/src/main/java/com/db/assetstore/domain/service/transform/JsonTransformer.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.schibsted.spt.data.jslt.Expression;
 import com.schibsted.spt.data.jslt.Parser;
 import com.db.assetstore.domain.service.validation.JsonSchemaValidator;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
@@ -14,7 +15,6 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.Objects;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.concurrent.ConcurrentHashMap;
@@ -29,10 +29,7 @@ public final class JsonTransformer {
 
     private final ConcurrentHashMap<String, Expression> expressionCache = new ConcurrentHashMap<>();
 
-    public String transform(String transformName, String inputJson) {
-        Objects.requireNonNull(transformName, "transformName");
-        Objects.requireNonNull(inputJson, "inputJson");
-
+    public String transform(@NonNull String transformName, @NonNull String inputJson) {
         String templatePath = "transforms/events/" + transformName + ".jslt";
         if (!resourceExists(templatePath)) {
             log.error("Transform template not found: {}", templatePath);

--- a/src/main/java/com/db/assetstore/domain/service/validation/AssetTypeValidator.java
+++ b/src/main/java/com/db/assetstore/domain/service/validation/AssetTypeValidator.java
@@ -4,13 +4,13 @@ import com.db.assetstore.AssetType;
 import com.db.assetstore.domain.model.attribute.AttributeValue;
 import com.db.assetstore.domain.service.type.TypeSchemaRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 @Component
@@ -21,17 +21,14 @@ public final class AssetTypeValidator {
     private final TypeSchemaRegistry registry;
     private final ObjectMapper objectMapper;
 
-    public void ensureSupported(AssetType type) {
-        Objects.requireNonNull(type, "type");
+    public void ensureSupported(@NonNull AssetType type) {
         Optional<String> schema = registry.getSchemaPath(type);
         if (schema.isEmpty()) {
             throw new IllegalArgumentException("Unsupported asset type: " + type + " - schema not found");
         }
     }
 
-    public void validateAttributes(AssetType type, Collection<AttributeValue<?>> attrs) {
-        Objects.requireNonNull(type, "type");
-        Objects.requireNonNull(attrs, "attrs");
+    public void validateAttributes(@NonNull AssetType type, @NonNull Collection<AttributeValue<?>> attrs) {
         String schemaPath = registry.getSchemaPath(type).orElse(null);
         Map<String, Object> map = new LinkedHashMap<>();
         for (AttributeValue<?> av : attrs) {

--- a/src/main/java/com/db/assetstore/infra/jpa/AttributeHistoryEntity.java
+++ b/src/main/java/com/db/assetstore/infra/jpa/AttributeHistoryEntity.java
@@ -4,11 +4,11 @@ import com.db.assetstore.domain.model.type.AttributeType;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import lombok.Setter;
 
 import java.math.BigDecimal;
 import java.time.Instant;
-import java.util.Objects;
 
 
 @Entity
@@ -47,14 +47,14 @@ public class AttributeHistoryEntity {
     @Column(name = "changed_at", nullable = false)
     private Instant changedAt;
 
-    public AttributeHistoryEntity(AttributeEntity attribute, Instant when) {
-        this.attribute = Objects.requireNonNull(attribute);
+    public AttributeHistoryEntity(@NonNull AttributeEntity attribute, @NonNull Instant when) {
+        this.attribute = attribute;
         this.asset     = attribute.getAsset();
         this.name      = attribute.getName();
         this.valueType = attribute.getValueType();
         this.valueStr  = attribute.getValueStr();
         this.valueNum  = attribute.getValueNum();
         this.valueBool = attribute.getValueBool();
-        this.changedAt = Objects.requireNonNull(when);
+        this.changedAt = when;
     }
 }

--- a/src/main/java/com/db/assetstore/infra/service/AssetService.java
+++ b/src/main/java/com/db/assetstore/infra/service/AssetService.java
@@ -15,6 +15,7 @@ import com.db.assetstore.infra.repository.AssetRepository;
 import com.db.assetstore.infra.repository.AttributeRepository;
 import com.db.assetstore.infra.service.AttributeComparator;
 import com.db.assetstore.infra.service.AttributeUpdater;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,7 +24,6 @@ import java.time.Instant;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.UUID;
 
 @Slf4j
@@ -36,9 +36,7 @@ public class AssetService {
     private final AssetRepository assetRepo;
     private final AttributeRepository attributeRepo;
 
-    public CommandResult<String> create(CreateAssetCommand command) {
-        Objects.requireNonNull(command, "command");
-
+    public CommandResult<String> create(@NonNull CreateAssetCommand command) {
         String assetId = resolveAssetId(command);
         Asset asset = Asset.builder()
                 .id(assetId)
@@ -60,10 +58,8 @@ public class AssetService {
         return new CommandResult<>(persistedId, persistedId);
     }
 
-    public CommandResult<Void> patch(PatchAssetCommand command) {
-        Objects.requireNonNull(command, "command");
-
-        String assetId = Objects.requireNonNull(command.assetId(), "assetId");
+    public CommandResult<Void> patch(@NonNull PatchAssetCommand command) {
+        String assetId = command.assetId();
         AssetPatch patch = AssetPatch.builder()
                 .status(command.status())
                 .subtype(command.subtype())
@@ -78,10 +74,8 @@ public class AssetService {
         return CommandResult.noResult(assetId);
     }
 
-    public CommandResult<Void> delete(DeleteAssetCommand command) {
-        Objects.requireNonNull(command, "command");
-
-        String assetId = Objects.requireNonNull(command.assetId(), "assetId");
+    public CommandResult<Void> delete(@NonNull DeleteAssetCommand command) {
+        String assetId = command.assetId();
         deleteAsset(assetId);
         return CommandResult.noResult(assetId);
     }
@@ -93,8 +87,7 @@ public class AssetService {
         return UUID.randomUUID().toString();
     }
 
-    private String persistAsset(Asset asset) {
-        Objects.requireNonNull(asset, "asset");
+    private String persistAsset(@NonNull Asset asset) {
         log.info("Adding asset: type={}, id={}", asset.getType(), asset.getId());
         AssetEntity entity = assetMapper.toEntity(asset);
         if (entity.getAttributes() != null && !entity.getAttributes().isEmpty()) {
@@ -105,10 +98,7 @@ public class AssetService {
         return entity.getId();
     }
 
-    private void applyPatch(String id, AssetPatch patch, String executedBy) {
-        Objects.requireNonNull(id, "id");
-        Objects.requireNonNull(patch, "patch");
-
+    private void applyPatch(@NonNull String id, @NonNull AssetPatch patch, String executedBy) {
         AssetEntity entity = assetRepo.findByIdAndDeleted(id, 0)
                 .orElseThrow(() -> new IllegalArgumentException("Asset not found: " + id));
 
@@ -139,17 +129,14 @@ public class AssetService {
         }
     }
 
-    private void deleteAsset(String id) {
-        Objects.requireNonNull(id, "id");
+    private void deleteAsset(@NonNull String id) {
         AssetEntity entity = assetRepo.findByIdAndDeleted(id, 0)
                 .orElseThrow(() -> new IllegalArgumentException("Asset not found: " + id));
         entity.setDeleted(1);
         assetRepo.save(entity);
     }
 
-    private void updateAsset(AssetEntity asset, Collection<AttributeValue<?>> attributes) {
-        Objects.requireNonNull(asset, "asset entity");
-        Objects.requireNonNull(attributes, "attributes");
+    private void updateAsset(@NonNull AssetEntity asset, @NonNull Collection<AttributeValue<?>> attributes) {
         if (attributes.isEmpty()) {
             return;
         }

--- a/src/main/java/com/db/assetstore/infra/service/cmd/CommandLogService.java
+++ b/src/main/java/com/db/assetstore/infra/service/cmd/CommandLogService.java
@@ -6,12 +6,12 @@ import com.db.assetstore.infra.jpa.CommandLogEntity;
 import com.db.assetstore.infra.repository.CommandLogRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
-import java.util.Objects;
 
 @Slf4j
 @Service
@@ -21,10 +21,7 @@ public class CommandLogService {
     private final CommandLogRepository commandLogRepository;
     private final ObjectMapper objectMapper;
 
-    public void record(CommandResult<?> result, AssetCommand<?> command) {
-        Objects.requireNonNull(result, "result");
-        Objects.requireNonNull(command, "command");
-
+    public void record(@NonNull CommandResult<?> result, @NonNull AssetCommand<?> command) {
         String commandType = command.commandType();
         String payload;
         try {

--- a/src/main/java/com/db/assetstore/infra/service/cmd/CommandServiceImpl.java
+++ b/src/main/java/com/db/assetstore/infra/service/cmd/CommandServiceImpl.java
@@ -11,12 +11,12 @@ import com.db.assetstore.domain.service.link.cmd.CreateAssetLinkCommand;
 import com.db.assetstore.domain.service.link.cmd.DeleteAssetLinkCommand;
 import com.db.assetstore.infra.service.link.AssetLinkService;
 import com.db.assetstore.infra.service.AssetService;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Objects;
 
 @Slf4j
 @Service
@@ -29,9 +29,7 @@ public class CommandServiceImpl implements AssetCommandService, AssetCommandVisi
 
     @Override
     @Transactional
-    public <R> CommandResult<R> execute(AssetCommand<R> command) {
-        Objects.requireNonNull(command, "command");
-
+    public <R> CommandResult<R> execute(@NonNull AssetCommand<R> command) {
         CommandResult<R> result = command.accept(this);
         if (result.success()) {
             commandLogService.record(result, command);

--- a/src/main/java/com/db/assetstore/infra/service/link/AssetLinkService.java
+++ b/src/main/java/com/db/assetstore/infra/service/link/AssetLinkService.java
@@ -7,12 +7,12 @@ import com.db.assetstore.infra.jpa.AssetLinkEntity;
 import com.db.assetstore.infra.jpa.LinkDefinitionEntity;
 import com.db.assetstore.infra.repository.AssetLinkRepo;
 import com.db.assetstore.infra.repository.LinkDefinitionRepo;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
-import java.util.Objects;
 import java.util.Optional;
 
 @Slf4j
@@ -24,9 +24,7 @@ public class AssetLinkService {
     private final LinkDefinitionRepo linkDefinitionRepo;
     private final AssetLinkCommandValidator assetLinkCommandValidator;
 
-    public CommandResult<Long> create(CreateAssetLinkCommand command) {
-        Objects.requireNonNull(command, "command");
-
+    public CommandResult<Long> create(@NonNull CreateAssetLinkCommand command) {
         LinkDefinitionEntity definition = findActiveDefinition(command);
         assetLinkCommandValidator.validateCreate(command, definition);
 
@@ -38,9 +36,7 @@ public class AssetLinkService {
         return new CommandResult<>(result.entity().getId(), command.assetId());
     }
 
-    public CommandResult<Void> delete(DeleteAssetLinkCommand command) {
-        Objects.requireNonNull(command, "command");
-
+    public CommandResult<Void> delete(@NonNull DeleteAssetLinkCommand command) {
         AssetLinkEntity entity = requireActiveLink(command);
         deactivateLink(command, entity);
         log.info("Deactivated link id={} for asset {}", entity.getId(), command.assetId());


### PR DESCRIPTION
## Summary
- replace Object.requireNonNull usages across services, factories, and domain models with Lombok's `@NonNull`
- add `@NonNull` annotations to command records and service methods to preserve validation semantics
- remove now-unneeded `java.util.Objects` imports and rely on Lombok-generated null checks

## Testing
- `mvn -q -DskipITs test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d5ade232348330b9fabcf733148cff