### PR TITLE
Prevent string attributes from accepting container nodes

### DIFF
--- a/src/main/java/com/db/assetstore/infra/json/AttributeValueAssembler.java
+++ b/src/main/java/com/db/assetstore/infra/json/AttributeValueAssembler.java
@@ -60,10 +60,17 @@ public class AttributeValueAssembler {
         }
 
         return switch (expectedType) {
-            case STRING -> node.asText();
+            case STRING -> parseString(raw.name(), node);
             case DECIMAL -> parseDecimal(raw.name(), node);
             case BOOLEAN -> parseBoolean(raw.name(), node);
         };
+    }
+
+    private String parseString(String name, JsonNode node) {
+        if (node.isTextual() || node.isNumber() || node.isBoolean()) {
+            return node.asText();
+        }
+        throw AttributeParsingException.incompatibleType(name, AttributeType.STRING, node.getNodeType().name());
     }
 
     private BigDecimal parseDecimal(String name, JsonNode node) {

--- a/src/test/java/com/db/assetstore/infra/json/AttributeJsonReaderTest.java
+++ b/src/test/java/com/db/assetstore/infra/json/AttributeJsonReaderTest.java
@@ -77,4 +77,26 @@ class AttributeJsonReaderTest {
                 .isInstanceOf(AttributeParsingException.class)
                 .hasMessageContaining("expects type BOOLEAN");
     }
+
+    @Test
+    void failsWhenStringValueIsObject() {
+        var payload = objectMapper.createObjectNode();
+        var nested = objectMapper.createObjectNode();
+        nested.put("city", "Warsaw");
+        payload.set("city", nested);
+
+        assertThatThrownBy(() -> reader.read(AssetType.CRE, payload))
+                .isInstanceOf(AttributeParsingException.class)
+                .hasMessageContaining("expects type STRING");
+    }
+
+    @Test
+    void failsWhenStringValueIsArray() {
+        var payload = objectMapper.createObjectNode();
+        payload.putArray("city").add("Warsaw");
+
+        assertThatThrownBy(() -> reader.read(AssetType.CRE, payload))
+                .isInstanceOf(AttributeParsingException.class)
+                .hasMessageContaining("expects type STRING");
+    }
 }


### PR DESCRIPTION
## Summary
- validate STRING attribute payloads using a dedicated parser that rejects non-scalar JSON nodes
- add regression tests ensuring objects and arrays supplied for string attributes raise parsing errors

## Testing
- mvn -q test *(fails: project does not compile due to missing MinMaxRule dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d2d6fbb88330bb304f9e97874fbb