### PR TITLE
Replace test attribute registry with default implementation

### DIFF
--- a/src/test/java/com/db/assetstore/domain/service/validation/AttributeValidatorTest.java
+++ b/src/test/java/com/db/assetstore/domain/service/validation/AttributeValidatorTest.java
@@ -12,7 +12,7 @@ import com.db.assetstore.domain.service.validation.rule.AttributeValidationError
 import com.db.assetstore.domain.service.validation.ValidationMode;
 import com.db.assetstore.domain.service.validation.rule.CustomValidationRuleRegistry;
 import com.db.assetstore.domain.service.validation.rule.ValidationRuleFactory;
-import com.db.assetstore.testutil.TestAttributeDefinitionRegistry;
+import com.db.assetstore.testutil.InMemoryAttributeDefinitionLoader;
 import com.db.assetstore.testutil.validation.MatchingAttributesRule;
 import org.junit.jupiter.api.Test;
 
@@ -250,9 +250,9 @@ class AttributeValidatorTest {
                                                 Map<String, List<ConstraintDefinition>> constraints) {
         var customRegistry = customRegistry();
         var factory = new ValidationRuleFactory(customRegistry);
-        var registry = TestAttributeDefinitionRegistry.builder()
+        var registry = InMemoryAttributeDefinitionLoader.builder()
                 .withAttributes(AssetType.CRE, defs, constraints)
-                .build();
+                .buildRegistry();
         return new AttributeValidator(registry, factory);
     }
 }

--- a/src/test/java/com/db/assetstore/infra/json/AttributeJsonReaderTest.java
+++ b/src/test/java/com/db/assetstore/infra/json/AttributeJsonReaderTest.java
@@ -6,7 +6,7 @@ import com.db.assetstore.domain.model.type.AVDecimal;
 import com.db.assetstore.domain.model.type.AVString;
 import com.db.assetstore.domain.model.type.AttributeType;
 import com.db.assetstore.domain.service.type.AttributeDefinitionRegistry;
-import com.db.assetstore.testutil.TestAttributeDefinitionRegistry;
+import com.db.assetstore.testutil.InMemoryAttributeDefinitionLoader;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,11 +29,11 @@ class AttributeJsonReaderTest {
         var area = definition(AssetType.CRE, "area", AttributeType.DECIMAL);
         var active = definition(AssetType.CRE, "active", AttributeType.BOOLEAN);
 
-        AttributeDefinitionRegistry registry = TestAttributeDefinitionRegistry.builder()
+        AttributeDefinitionRegistry registry = InMemoryAttributeDefinitionLoader.builder()
                 .withAttribute(city, constraint(city, TYPE))
                 .withAttribute(area, constraint(area, TYPE))
                 .withAttribute(active, constraint(active, TYPE))
-                .build();
+                .buildRegistry();
 
         reader = new AttributeJsonReader(
                 new AttributePayloadParser(),

--- a/src/test/java/com/db/assetstore/infra/service/cmd/AssetCommandFactoryRegistryTest.java
+++ b/src/test/java/com/db/assetstore/infra/service/cmd/AssetCommandFactoryRegistryTest.java
@@ -22,7 +22,7 @@ import com.db.assetstore.infra.api.dto.AssetPatchRequest;
 import com.db.assetstore.infra.json.AttributeJsonReader;
 import com.db.assetstore.infra.json.AttributePayloadParser;
 import com.db.assetstore.infra.json.AttributeValueAssembler;
-import com.db.assetstore.testutil.TestAttributeDefinitionRegistry;
+import com.db.assetstore.testutil.InMemoryAttributeDefinitionLoader;
 import com.db.assetstore.testutil.validation.MatchingAttributesRule;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -58,14 +58,14 @@ class AssetCommandFactoryRegistryTest {
         var imo = definition(AssetType.SHIP, "imo", AttributeType.DECIMAL);
         var shipActive = definition(AssetType.SHIP, "active", AttributeType.BOOLEAN);
 
-        attributeDefinitionRegistry = TestAttributeDefinitionRegistry.builder()
+        attributeDefinitionRegistry = InMemoryAttributeDefinitionLoader.builder()
                 .withAttribute(city, constraint(city, TYPE))
                 .withAttribute(area, constraint(area, TYPE))
                 .withAttribute(active, constraint(active, TYPE))
                 .withAttribute(name, constraint(name, TYPE), constraint(name, REQUIRED))
                 .withAttribute(imo, constraint(imo, TYPE))
                 .withAttribute(shipActive, constraint(shipActive, TYPE))
-                .build();
+                .buildRegistry();
         customRegistry = new CustomValidationRuleRegistry(List.of(new MatchingAttributesRule()));
         validationRuleFactory = ruleFactory(customRegistry);
         AttributeValidator attributeValidator = new AttributeValidator(attributeDefinitionRegistry, validationRuleFactory);

--- a/src/test/java/com/db/assetstore/infra/service/cmd/CreateAssetCommandFactoryTest.java
+++ b/src/test/java/com/db/assetstore/infra/service/cmd/CreateAssetCommandFactoryTest.java
@@ -11,12 +11,12 @@ import com.db.assetstore.domain.service.type.AttributeDefinitionRegistry;
 import com.db.assetstore.domain.service.validation.AttributeValidator;
 import com.db.assetstore.domain.service.validation.rule.CustomValidationRuleRegistry;
 import com.db.assetstore.domain.service.validation.rule.ValidationRuleFactory;
-import com.db.assetstore.testutil.TestAttributeDefinitionRegistry;
 import com.db.assetstore.infra.api.dto.AssetCreateRequest;
 import com.db.assetstore.infra.json.AttributeJsonReader;
 import com.db.assetstore.infra.json.AttributePayloadParser;
 import com.db.assetstore.infra.json.AttributeValueAssembler;
 import com.db.assetstore.testutil.validation.MatchingAttributesRule;
+import com.db.assetstore.testutil.InMemoryAttributeDefinitionLoader;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,12 +42,12 @@ class CreateAssetCommandFactoryTest {
         var area = definition(AssetType.CRE, "area", AttributeType.DECIMAL);
         var active = definition(AssetType.CRE, "active", AttributeType.BOOLEAN);
 
-        registry = TestAttributeDefinitionRegistry.builder()
+        registry = InMemoryAttributeDefinitionLoader.builder()
                 .withAttribute(city, constraint(city, TYPE))
                 .withAttribute(area, constraint(area, TYPE))
                 .withAttribute(active, constraint(active, TYPE))
                 .withAssetType(AssetType.SHIP)
-                .build();
+                .buildRegistry();
         customRegistry = new CustomValidationRuleRegistry(List.of(new MatchingAttributesRule()));
         var validator = new AttributeValidator(registry, ruleFactory(customRegistry));
         AttributeJsonReader reader = new AttributeJsonReader(

--- a/src/test/java/com/db/assetstore/infra/service/cmd/PatchAssetCommandFactoryTest.java
+++ b/src/test/java/com/db/assetstore/infra/service/cmd/PatchAssetCommandFactoryTest.java
@@ -16,7 +16,7 @@ import com.db.assetstore.infra.api.dto.AssetPatchRequest;
 import com.db.assetstore.infra.json.AttributeJsonReader;
 import com.db.assetstore.infra.json.AttributePayloadParser;
 import com.db.assetstore.infra.json.AttributeValueAssembler;
-import com.db.assetstore.testutil.TestAttributeDefinitionRegistry;
+import com.db.assetstore.testutil.InMemoryAttributeDefinitionLoader;
 import com.db.assetstore.testutil.validation.MatchingAttributesRule;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -46,12 +46,12 @@ class PatchAssetCommandFactoryTest {
         var imo = definition(AssetType.SHIP, "imo", AttributeType.DECIMAL);
         var active = definition(AssetType.SHIP, "active", AttributeType.BOOLEAN);
 
-        registry = TestAttributeDefinitionRegistry.builder()
+        registry = InMemoryAttributeDefinitionLoader.builder()
                 .withAttribute(name, constraint(name, TYPE), constraint(name, REQUIRED))
                 .withAttribute(imo, constraint(imo, TYPE))
                 .withAttribute(active, constraint(active, TYPE))
                 .withAssetType(AssetType.CRE)
-                .build();
+                .buildRegistry();
         customRegistry = new CustomValidationRuleRegistry(List.of(new MatchingAttributesRule()));
         AttributeValidator validator = new AttributeValidator(registry, ruleFactory(customRegistry));
         AttributeJsonReader reader = new AttributeJsonReader(


### PR DESCRIPTION
## Summary
- replace the bespoke `TestAttributeDefinitionRegistry` with an in-memory `AttributeDefinitionLoader`
- update tests to build registries via the production `DefaultAttributeDefinitionRegistry`

## Testing
- `mvn -q test` *(fails: existing compilation errors in MinMaxRule/RequiredRule referencing missing types)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d5a6f87483308d8ea8bca2888247