### PR TITLE
Adjust custom validation tests to SPV asset type

### DIFF
--- a/src/test/java/com/db/assetstore/infra/service/type/AttributeDefinitionRegistryImplIntegrationTest.java
+++ b/src/test/java/com/db/assetstore/infra/service/type/AttributeDefinitionRegistryImplIntegrationTest.java
@@ -49,14 +49,14 @@ class AttributeDefinitionRegistryImplIntegrationTest {
 
     @Test
     void schemaDefinitionsOverrideDatabaseValues() {
-        AttributeDefEntity city = new AttributeDefEntity(AssetType.CRE, "city", AttributeType.DECIMAL, false);
+        AttributeDefEntity city = new AttributeDefEntity(AssetType.SPV, "city", AttributeType.DECIMAL, false);
         city.getConstraints().add(new ConstraintDefEntity(city, ConstraintDefinition.Rule.CUSTOM,
                 "matchingAttributes"));
         attributeDefRepository.save(city);
-        attributeDefRepository.save(new AttributeDefEntity(AssetType.CRE, "custom", AttributeType.STRING, true));
+        attributeDefRepository.save(new AttributeDefEntity(AssetType.SPV, "custom", AttributeType.STRING, true));
 
-        Map<String, AttributeDefinition> definitions = registry.getDefinitions(AssetType.CRE);
-        Map<String, List<ConstraintDefinition>> constraints = registry.getConstraints(AssetType.CRE);
+        Map<String, AttributeDefinition> definitions = registry.getDefinitions(AssetType.SPV);
+        Map<String, List<ConstraintDefinition>> constraints = registry.getConstraints(AssetType.SPV);
 
         assertThat(definitions).containsKeys("city", "area", "rooms", "active", "custom");
         AttributeDefinition cityDef = definitions.get("city");
@@ -77,7 +77,7 @@ class AttributeDefinitionRegistryImplIntegrationTest {
 
     @Test
     void schemaCustomRulesAreResolvedByName() {
-        Map<String, List<ConstraintDefinition>> constraints = registry.getConstraints(AssetType.CRE);
+        Map<String, List<ConstraintDefinition>> constraints = registry.getConstraints(AssetType.SPV);
 
         assertThat(constraints.getOrDefault("rooms", List.of()))
                 .anySatisfy(c -> {

--- a/src/test/java/com/db/assetstore/service/TypeSchemaRegistryTest.java
+++ b/src/test/java/com/db/assetstore/service/TypeSchemaRegistryTest.java
@@ -24,6 +24,6 @@ class TypeSchemaRegistryTest {
         assertTrue(supported.contains(AssetType.SHIP), "SHIP should be supported");
 
         assertFalse(supported.contains(AssetType.AV), "AV should not be supported without schema");
-        assertFalse(supported.contains(AssetType.SPV), "SPV should not be supported without schema");
+        assertTrue(supported.contains(AssetType.SPV), "SPV should be supported");
     }
 }

--- a/src/test/resources/schemas/types/CRE.schema.json
+++ b/src/test/resources/schemas/types/CRE.schema.json
@@ -4,17 +4,9 @@
   "type": "object",
   "properties": {
     "id": { "type": "string" },
-    "city": {
-      "type": "string",
-      "x-customRules": [
-        "matchingAttributes"
-      ]
-    },
+    "city": { "type": "string" },
     "area": { "type": "number" },
-    "rooms": {
-      "type": "integer",
-      "x-customRules": "matchingAttributes"
-    },
+    "rooms": { "type": "integer" },
     "active": { "type": "boolean" }
   },
   "required": [ "city" ]

--- a/src/test/resources/schemas/types/SPV.schema.json
+++ b/src/test/resources/schemas/types/SPV.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Special Purpose Vehicle Asset",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" },
+    "city": {
+      "type": "string",
+      "x-customRules": [
+        "matchingAttributes"
+      ]
+    },
+    "area": { "type": "number" },
+    "rooms": {
+      "type": "integer",
+      "x-customRules": "matchingAttributes"
+    },
+    "active": { "type": "boolean" }
+  },
+  "required": [ "city" ]
+}


### PR DESCRIPTION
## Summary
- move the custom validation rule definitions in the JSON schemas from CRE to SPV
- update the attribute definition integration test to assert SPV-only custom rules
- expect the type schema registry to pick up the SPV schema during discovery

## Testing
- `mvn -Dtest=TypeSchemaRegistryTest,AttributeDefinitionRegistryImplIntegrationTest test` *(fails: compilation errors in MinMaxRule and RequiredRule due to missing symbols in the existing codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68d829c6883c8330a9dc6b4002b15daa